### PR TITLE
Add CSRF tokens to settings UI and move page to Settings menu

### DIFF
--- a/gow.plg
+++ b/gow.plg
@@ -3,7 +3,7 @@
 <!ENTITY name      "gow">
 <!ENTITY author    "games-on-whales">
 <!ENTITY org       "games-on-whales">
-<!ENTITY version   "2026.04.14">
+<!ENTITY version   "2026.04.24">
 <!ENTITY launch    "Settings/gow">
 <!ENTITY gitURL    "https://raw.githubusercontent.com/&org;/unraid-plugin/main">
 <!ENTITY gitPkgURL "https://raw.githubusercontent.com/&org;/unraid-plugin/&version;">
@@ -25,6 +25,10 @@
 >
 
   <CHANGES>
+### 2026.04.24
+- Add CSRF tokens to all settings UI forms (Unraid webGui rejects POSTs without them)
+- Move plugin page from Utilities to Settings menu to match launch target
+
 ### 2026.04.14
 - Fix white screen when clicking Install (exec blocking + JS redirect)
 - Fix GPU_NAME with spaces breaking bash config sourcing (single-quote values)

--- a/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
+++ b/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
@@ -1,4 +1,4 @@
-Menu="Utilities"
+Menu="Settings"
 Title="Games on Whales"
 Icon="gow.png"
 ---
@@ -115,7 +115,13 @@ $message = '';
 $error   = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $action = $_POST['action'] ?? '';
+    // Reject POSTs that don't carry Unraid's CSRF token.
+    if (empty($_POST['csrf_token']) || $_POST['csrf_token'] !== $var['csrf_token']) {
+        $error  = 'Invalid CSRF token. Please reload the page and try again.';
+        $action = '';
+    } else {
+        $action = $_POST['action'] ?? '';
+    }
 
     if ($action === 'save_and_deploy') {
         // Validate and persist GPU selection + appdata path
@@ -279,18 +285,22 @@ $ip       = local_ip();
   <div class="gow-title">Actions</div>
   <div class="gow-actions">
     <form method="post" style="display:inline">
+      <input type="hidden" name="csrf_token" value="<?=$var['csrf_token']?>">
       <input type="hidden" name="action" value="start">
       <button type="submit" class="gow-btn gow-btn-primary">Start</button>
     </form>
     <form method="post" style="display:inline">
+      <input type="hidden" name="csrf_token" value="<?=$var['csrf_token']?>">
       <input type="hidden" name="action" value="stop">
       <button type="submit" class="gow-btn gow-btn-secondary">Stop</button>
     </form>
     <form method="post" style="display:inline">
+      <input type="hidden" name="csrf_token" value="<?=$var['csrf_token']?>">
       <input type="hidden" name="action" value="update">
       <button type="submit" class="gow-btn gow-btn-secondary">Update Images</button>
     </form>
     <form method="post" style="display:inline">
+      <input type="hidden" name="csrf_token" value="<?=$var['csrf_token']?>">
       <input type="hidden" name="action" value="reconfigure">
       <button type="submit" class="gow-btn gow-btn-danger"
               onclick="return confirm('This will let you change GPU and appdata settings. The stack will be restarted. Continue?')">
@@ -306,6 +316,7 @@ $ip       = local_ip();
   <div class="gow-title">Games on Whales — Setup</div>
 
   <form method="post">
+    <input type="hidden" name="csrf_token" value="<?=$var['csrf_token']?>">
     <input type="hidden" name="action" value="save_and_deploy">
 
     <div class="gow-row" style="flex-direction:column;align-items:flex-start;gap:6px">

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -2,7 +2,7 @@
 # vars.sh — shared environment for all GoW plugin scripts
 
 export GOW_NAME="gow"
-export GOW_VERSION="2026.04.14"
+export GOW_VERSION="2026.04.24"
 export GOW_ORG="games-on-whales"
 export GOW_PLUGIN="/boot/config/plugins/gow"
 export GOW_CFG="${GOW_PLUGIN}/gow.cfg"


### PR DESCRIPTION
Stacks on top of #18. Addresses tester feedback on the wolf-plugin-rewrite branch.

## Summary
- Add Unraid webGui CSRF token (hidden input) to all five POST forms in gow.page: save_and_deploy, start, stop, update, reconfigure. Without it, Unraid silently drops the submissions on a hardened install.
- Validate the token server-side in the POST handler; reject mismatches with an inline error instead of acting on the request.
- Change Menu="Utilities" to Menu="Settings" so the plugin page appears under Settings, matching the launch="Settings/gow" already set in gow.plg.
- Bump version to 2026.04.24 in gow.plg and scripts/vars.sh so the release workflow builds a fresh settings-ui.txz with matching hashes. Changelog entry added.

## Test plan
- [ ] Install the plugin on an Unraid 6.12+ system and confirm the page appears under Settings, not Tools.
- [ ] Click Install, Start, Stop, Update Images, and Reconfigure; each should act on the request (no silent drops).
- [ ] Tamper with the csrf_token value via DevTools and resubmit; the page should render the "Invalid CSRF token" error and take no action.
- [ ] Verify the 2026.04.24 tag triggers a release with settings-ui.txz + matching sha256/md5 sidecars.