### PR TITLE
Require Docker Compose at preinstall

### DIFF
--- a/gow.plg
+++ b/gow.plg
@@ -3,7 +3,7 @@
 <!ENTITY name      "gow">
 <!ENTITY author    "games-on-whales">
 <!ENTITY org       "games-on-whales">
-<!ENTITY version   "2026.04.24">
+<!ENTITY version   "2026.04.25">
 <!ENTITY launch    "Settings/gow">
 <!ENTITY gitURL    "https://raw.githubusercontent.com/&org;/unraid-plugin/main">
 <!ENTITY gitPkgURL "https://raw.githubusercontent.com/&org;/unraid-plugin/&version;">
@@ -25,6 +25,9 @@
 >
 
   <CHANGES>
+### 2026.04.25
+- Require Docker Compose (Compose Manager plugin) at preinstall, matching deploy/start/stop/update dependencies
+
 ### 2026.04.24
 - Add CSRF tokens to all settings UI forms (Unraid webGui rejects POSTs without them)
 - Move plugin page from Utilities to Settings menu to match launch target

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -30,6 +30,13 @@ check_docker() {
     info "Docker OK"
 }
 
+check_docker_compose() {
+    if ! docker compose version &>/dev/null; then
+        err "Docker Compose is not available. Install the 'Compose Manager' plugin from Community Applications, then try again."
+    fi
+    info "Docker Compose OK"
+}
+
 check_nvidia() {
     local has_nvidia=false has_other=false driver
 
@@ -68,6 +75,7 @@ check_network() {
 
 check_unraid_version
 check_docker
+check_docker_compose
 check_nvidia
 check_network
 

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -2,7 +2,7 @@
 # vars.sh — shared environment for all GoW plugin scripts
 
 export GOW_NAME="gow"
-export GOW_VERSION="2026.04.24"
+export GOW_VERSION="2026.04.25"
 export GOW_ORG="games-on-whales"
 export GOW_PLUGIN="/boot/config/plugins/gow"
 export GOW_CFG="${GOW_PLUGIN}/gow.cfg"


### PR DESCRIPTION
Stacks on top of #18. Adds a missing dependency check.

## Summary
- \`deploy.sh\` and the Start/Stop/Update/Reconfigure actions in the settings UI all call \`docker compose\`, but \`preinstall.sh\` never verified it exists. On stock Unraid 6.12+ without the Compose Manager plugin from Community Applications, the install finishes clean and every button then fails at runtime with a cryptic 'command not found'.
- Added \`check_docker_compose()\` that runs \`docker compose version\` and aborts with a clear pointer to the Compose Manager plugin, matching the existing \`check_nvidia()\` pattern.
- Version bumped to 2026.04.25 in gow.plg and scripts/vars.sh so the release workflow picks it up on tag. 2026.04.24 was already consumed by #19 and the workflow's tag regex is strict YYYY.MM.DD.

## Test plan
- [ ] On an Unraid 6.12+ system without Compose Manager: install the plugin, confirm preinstall aborts with the 'install Compose Manager' message.
- [ ] Install Compose Manager from CA, retry, confirm preinstall succeeds and the GoW install completes.
- [ ] Tag 2026.04.25 after merge to trigger the release workflow.