### PR TITLE
Pin container_name to wolf and wolf-den in generated compose

### DIFF
--- a/gow.plg
+++ b/gow.plg
@@ -27,6 +27,7 @@
   <CHANGES>
 ### 2026.04.25
 - Require Docker Compose (Compose Manager plugin) at preinstall, matching deploy/start/stop/update dependencies
+- Pin container_name to wolf/wolf-den in generated docker-compose.yml so the settings UI status badges report Running instead of Not deployed
 
 ### 2026.04.24
 - Add CSRF tokens to all settings UI forms (Unraid webGui rejects POSTs without them)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -94,6 +94,7 @@ write_compose_nvidia() {
 services:
   wolf:
     image: ghcr.io/games-on-whales/wolf:stable
+    container_name: wolf
     environment:
       - WOLF_RENDER_NODE=${RENDER_NODE}
       - NVIDIA_DRIVER_VOLUME_NAME=nvidia-driver-vol
@@ -126,6 +127,7 @@ services:
 
   wolf-den:
     image: ghcr.io/games-on-whales/wolf-den:stable
+    container_name: wolf-den
     environment:
       - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60
@@ -151,6 +153,7 @@ write_compose_standard() {
 services:
   wolf:
     image: ghcr.io/games-on-whales/wolf:stable
+    container_name: wolf
     environment:
       - WOLF_RENDER_NODE=${RENDER_NODE}
       - XDG_RUNTIME_DIR=/tmp/sockets
@@ -174,6 +177,7 @@ services:
 
   wolf-den:
     image: ghcr.io/games-on-whales/wolf-den:stable
+    container_name: wolf-den
     environment:
       - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60


### PR DESCRIPTION
Stacks on top of #20 (which stacks on #18). Fixes the "Not deployed" status badges the tester reported.

## Summary
Without \`container_name\`, Docker Compose v2 names containers \`<project>-<service>-1\`, i.e. \`gow-wolf-1\` and \`gow-wolf-den-1\` under the default \`APPDATA=/mnt/user/appdata/gow\`. But \`gow.page\` calls \`docker inspect wolf\` / \`docker inspect wolf-den\`, so every deployed install showed "Not deployed" badges even with both containers running.

Added \`container_name: wolf\` and \`container_name: wolf-den\` to both services in both compose templates (NVIDIA + standard in \`deploy.sh\`). No PHP changes needed — the inspect calls now resolve.

Changelog entry for 2026.04.25 extended to mention this fix; no extra version bump (both #20 and this PR land as 2026.04.25).

## Migration
- **Fresh installs:** work out of the box.
- **Existing installs:** \`deploy.sh\` already runs \`docker compose down\` before rewriting the compose file, so clicking **Reconfigure** once is enough to tear down the old mangled containers and bring up the newly-named ones. Plain \`update.sh\` does not regenerate the compose file, so "Update Images" alone won't migrate — flagged in the PR body so maintainers can mention it in release notes if needed.

## Test plan
- [ ] Fresh install on a clean Unraid box → settings UI shows Running for both Wolf and Wolf Den.
- [ ] Upgrade from a pre-2026.04.25 install, click Reconfigure → old \`gow-wolf-1\`/\`gow-wolf-den-1\` containers removed, new \`wolf\`/\`wolf-den\` containers running, status badges switch to Running.