### PR TITLE
Container names + Compose Manager plg-level check (2026.04.25 followups)

### DIFF
--- a/gow.plg
+++ b/gow.plg
@@ -26,7 +26,7 @@
 
   <CHANGES>
 ### 2026.04.25
-- Require Docker Compose (Compose Manager plugin) at preinstall, matching deploy/start/stop/update dependencies
+- Require the Compose Manager plugin (checked at plg install time) since deploy/start/stop/update all call docker compose
 - Pin container_name to wolf/wolf-den in generated docker-compose.yml so the settings UI status badges report Running instead of Not deployed
 
 ### 2026.04.24
@@ -47,6 +47,22 @@
 - Persistent udev rules and auto-start via /boot/config/go
 - Requires Unraid 6.12+
   </CHANGES>
+
+  <!-- Hard dependency: Compose Manager plugin must be installed first. -->
+  <FILE Run="/bin/bash">
+    <INLINE>
+      if [ ! -f /boot/config/plugins/compose.manager.plg ]; then
+        echo ""
+        echo "-----------------------------------------------------------"
+        echo " &name; has not been installed!"
+        echo " Install the 'Compose Manager' plugin from Community"
+        echo " Applications first, then retry."
+        echo "-----------------------------------------------------------"
+        echo ""
+        exit 1
+      fi
+    </INLINE>
+  </FILE>
 
   <!-- Remove stale packages from previous versions -->
   <FILE Run="/bin/bash">

--- a/gow.plg
+++ b/gow.plg
@@ -27,6 +27,7 @@
   <CHANGES>
 ### 2026.04.25
 - Require Docker Compose (Compose Manager plugin) at preinstall, matching deploy/start/stop/update dependencies
+- Pin container_name to wolf/wolf-den in generated docker-compose.yml so the settings UI status badges report Running instead of Not deployed
 
 ### 2026.04.24
 - Add CSRF tokens to all settings UI forms (Unraid webGui rejects POSTs without them)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -94,6 +94,7 @@ write_compose_nvidia() {
 services:
   wolf:
     image: ghcr.io/games-on-whales/wolf:stable
+    container_name: wolf
     environment:
       - WOLF_RENDER_NODE=${RENDER_NODE}
       - NVIDIA_DRIVER_VOLUME_NAME=nvidia-driver-vol
@@ -126,6 +127,7 @@ services:
 
   wolf-den:
     image: ghcr.io/games-on-whales/wolf-den:stable
+    container_name: wolf-den
     environment:
       - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60
@@ -151,6 +153,7 @@ write_compose_standard() {
 services:
   wolf:
     image: ghcr.io/games-on-whales/wolf:stable
+    container_name: wolf
     environment:
       - WOLF_RENDER_NODE=${RENDER_NODE}
       - XDG_RUNTIME_DIR=/tmp/sockets
@@ -174,6 +177,7 @@ services:
 
   wolf-den:
     image: ghcr.io/games-on-whales/wolf-den:stable
+    container_name: wolf-den
     environment:
       - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -30,13 +30,6 @@ check_docker() {
     info "Docker OK"
 }
 
-check_docker_compose() {
-    if ! docker compose version &>/dev/null; then
-        err "Docker Compose is not available. Install the 'Compose Manager' plugin from Community Applications, then try again."
-    fi
-    info "Docker Compose OK"
-}
-
 check_nvidia() {
     local has_nvidia=false has_other=false driver
 
@@ -75,7 +68,6 @@ check_network() {
 
 check_unraid_version
 check_docker
-check_docker_compose
 check_nvidia
 check_network
 


### PR DESCRIPTION
Three commits that belong on \`wolf-plugin-rewrite\` but got parked on the \`require-docker-compose\` branch when #21 landed into the wrong base. Stacks on #18.

## Summary
- **feeb9b8** — Pin \`container_name: wolf\` and \`container_name: wolf-den\` in both compose templates. Without this, Compose v2 auto-names containers \`gow-wolf-1\` / \`gow-wolf-den-1\` and the settings UI's \`docker inspect wolf\` / \`docker inspect wolf-den\` probes miss, so the dashboard shows "Not deployed" even when the stack is running. (Was originally #21, merged into the PR #20 branch instead of \`wolf-plugin-rewrite\`.)
- **32a838b** — Replace the runtime \`docker compose version\` probe in \`preinstall.sh\` with a plg-level \`<FILE Run>\` check for \`/boot/config/plugins/compose.manager.plg\`, matching the pattern Unassigned Devices Plus uses to require Unassigned Devices. Fails earlier (before any scripts are downloaded) and is explicit about the required Community Applications plugin.

## Test plan
- [ ] Install plg without Compose Manager → abort message referencing Compose Manager, no scripts downloaded.
- [ ] Install plg with Compose Manager → install proceeds, preinstall.sh passes, deploy completes.
- [ ] Fresh deploy → containers named \`wolf\` and \`wolf-den\`, settings UI shows Running.
- [ ] Reconfigure from an install still using \`gow-wolf-1\` names → compose down removes the old ones, new \`wolf\`/\`wolf-den\` come up, dashboard updates.