### PR TITLE
Warn on missing nvidia_drm.modeset and add FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ success!
 plugin: gow.plg installed
 ```
 
+## Troubleshooting
+
+See [docs/FAQ.md](docs/FAQ.md). NVIDIA users in particular should read the
+`nvidia_drm.modeset` section before reporting black-screen or crashed-Wolf
+issues.
+
 ## Developer Notes
 
 See [DEVELOPING.md](DEVELOPING.md)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,30 @@
+# FAQ
+
+## NVIDIA Wayland support (nvidia_drm.modeset)
+
+Wolf composes its game stream through a Wayland compositor, and Wayland on
+NVIDIA hardware requires the `nvidia_drm` kernel module to load with
+`modeset=1`. Without it, Wolf either fails to start the compositor or the
+remote client shows a black frame.
+
+### Check
+
+```bash
+cat /sys/module/nvidia_drm/parameters/modeset
+```
+
+This should print `Y`. If it prints `N`, or the file does not exist, modeset
+is off.
+
+### Fix
+
+1. Open **Tools > System Drivers** in the Unraid webGui.
+2. Find `nvidia_drm` in the driver list.
+3. Set the `modeset` parameter to `1` (or `Y`).
+4. Apply the change and reboot so the module reloads with the new parameter.
+
+### References
+
+- Unraid forum thread: https://forums.unraid.net/topic/98978-plugin-nvidia-driver/page/164/#findComment-1425257
+- Short summary: "for Wayland support, you need to set `nvidia_drm` modeset
+  in Tools > System Drivers for your driver, then restart."

--- a/gow.plg
+++ b/gow.plg
@@ -3,7 +3,7 @@
 <!ENTITY name      "gow">
 <!ENTITY author    "games-on-whales">
 <!ENTITY org       "games-on-whales">
-<!ENTITY version   "2026.04.25">
+<!ENTITY version   "2026.04.26">
 <!ENTITY launch    "Settings/gow">
 <!ENTITY gitURL    "https://raw.githubusercontent.com/&org;/unraid-plugin/main">
 <!ENTITY gitPkgURL "https://raw.githubusercontent.com/&org;/unraid-plugin/&version;">
@@ -25,6 +25,9 @@
 >
 
   <CHANGES>
+### 2026.04.26
+- Detect missing nvidia_drm.modeset and warn in the settings UI (setup form + dashboard) with a link to the new FAQ entry; does not modify kernel module parameters automatically
+
 ### 2026.04.25
 - Require the Compose Manager plugin (checked at plg install time) since deploy/start/stop/update all call docker compose
 - Pin container_name to wolf/wolf-den in generated docker-compose.yml so the settings UI status badges report Running instead of Not deployed

--- a/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
+++ b/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
@@ -108,6 +108,16 @@ function local_ip() {
     return trim(explode(' ', $out[0] ?? '')[0]);
 }
 
+// Wolf composes through Wayland; on NVIDIA this requires nvidia_drm.modeset=Y
+// or the client gets a black screen. See docs/FAQ.md.
+function nvidia_drm_modeset_ok() {
+    $path = '/sys/module/nvidia_drm/parameters/modeset';
+    if (!is_readable($path)) return false;
+    return trim(@file_get_contents($path)) === 'Y';
+}
+
+define('FAQ_MODESET_URL', 'https://github.com/games-on-whales/unraid-plugin/blob/main/docs/FAQ.md#nvidia-wayland-support-nvidia_drmmodeset');
+
 // ── Action handlers ───────────────────────────────────────────────────────────
 
 $cfg     = load_cfg();
@@ -253,6 +263,17 @@ $ip       = local_ip();
 
 <?php elseif ($deployed): ?>
 <!-- ── Dashboard ─────────────────────────────────────────────────────────── -->
+<?php if ($cfg['GPU_VENDOR'] === 'NVIDIA' && !nvidia_drm_modeset_ok()): ?>
+  <div class="gow-msg err">
+    <strong>NVIDIA Wayland not enabled.</strong>
+    <code>/sys/module/nvidia_drm/parameters/modeset</code> is not <code>Y</code>,
+    so Wolf will fail to compose or the client will see a black screen. Open
+    <strong>Tools &gt; System Drivers</strong>, set <code>nvidia_drm</code>
+    modeset to <code>1</code>, apply, and reboot.
+    <a href="<?= FAQ_MODESET_URL ?>" target="_blank" style="color:#ef9a9a;text-decoration:underline">Details</a>.
+  </div>
+<?php endif; ?>
+
 <div class="gow-card">
   <div class="gow-title">Games on Whales</div>
 
@@ -348,6 +369,20 @@ $ip       = local_ip();
     <p style="color:#ffcc80;margin-top:12px">
       ⚠ NVIDIA GPU selected. On first install, a driver volume will be built — this can take
       5–10 minutes. The page will show progress while it runs.
+    </p>
+    <?php endif; ?>
+
+    <?php
+      $has_nvidia = false;
+      foreach ($gpus as $g) { if ($g['vendor'] === 'NVIDIA') { $has_nvidia = true; break; } }
+    ?>
+    <?php if ($has_nvidia && !nvidia_drm_modeset_ok()): ?>
+    <p style="color:#ef9a9a;margin-top:12px">
+      ⚠ NVIDIA detected but <code>nvidia_drm.modeset</code> is not enabled. Wolf's
+      Wayland compositor will not work until you set it. Open
+      <strong>Tools &gt; System Drivers</strong>, set <code>nvidia_drm</code>
+      modeset to <code>1</code>, apply, and reboot before installing.
+      <a href="<?= FAQ_MODESET_URL ?>" target="_blank" style="color:#ef9a9a;text-decoration:underline">Details</a>.
     </p>
     <?php endif; ?>
 

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -2,7 +2,7 @@
 # vars.sh — shared environment for all GoW plugin scripts
 
 export GOW_NAME="gow"
-export GOW_VERSION="2026.04.25"
+export GOW_VERSION="2026.04.26"
 export GOW_ORG="games-on-whales"
 export GOW_PLUGIN="/boot/config/plugins/gow"
 export GOW_CFG="${GOW_PLUGIN}/gow.cfg"


### PR DESCRIPTION
Stacks on #18. Does not automate the fix (modeset is a kernel module parameter; silently flipping it could affect anything else that touches nvidia_drm). Instead: detect, warn, document.

## Summary
- \`gow.page\` reads \`/sys/module/nvidia_drm/parameters/modeset\` on every page load via a new \`nvidia_drm_modeset_ok()\` helper.
- When NVIDIA hardware is present (any detected GPU on the setup form, or the configured GPU on the dashboard) and modeset is not \`Y\`, a red warning block appears pointing at **Tools > System Drivers** and linking to the FAQ.
- New \`docs/FAQ.md\` with an \`nvidia_drm.modeset\` section: the check command, the fix steps (Tools > System Drivers > set modeset to 1 > apply > reboot), and a reference to the Unraid forum discussion.
- README gets a Troubleshooting section pointing at the FAQ.
- Version bumped to 2026.04.26.

## Test plan
- [ ] On an NVIDIA system with modeset off: fresh install shows the setup-form warning; after deploying (if you proceed anyway), the dashboard shows the same warning.
- [ ] On an NVIDIA system with modeset=Y: no warning in either place.
- [ ] On a non-NVIDIA system: no warning (the helper short-circuits on the vendor check).
- [ ] FAQ link opens to the right anchor on the repo's main branch after this merges to main.