### PR TITLE
Add Community Applications submission templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,44 @@
-# unraid-plugin
+# Games on Whales — Unraid plugin
 
-A plugin for running Games on Whales on Unraid
+Run [Games on Whales](https://games-on-whales.github.io) on your Unraid
+server: stream games and desktops to any [Moonlight](https://moonlight-stream.org)
+client (Steam Deck, Apple TV, mobile, desktop) over your LAN or the internet.
 
-## Important Note
+The plugin deploys [Wolf](https://github.com/games-on-whales/wolf) (the
+streaming server) and [Wolf Den](https://github.com/games-on-whales/wolf-den)
+(the on-host launcher UI) via Docker Compose, and adds a Settings page under
+**Settings → Games on Whales** for picking a GPU, choosing your appdata path,
+and starting/stopping the stack.
 
-This plugin is still a work in progress.  While several people have found it
-useful, it is still at least theoretically possible there could be issues with it;
-possibly even issues that we don't know how to help you fix.  Having said that,
-it doesn't do anything permanent to your system, so uninstalling the plugin
-should be a good last-resort solution.
+## Status
+
+Beta. Several people are running it daily, but rough edges still exist. The
+plugin doesn't make permanent changes to your system — uninstalling is a
+clean rollback if anything goes wrong.
+
+## Requirements
+
+- Unraid 6.12 or newer
+- The **Compose Manager** plugin (install from Community Applications first —
+  the GoW installer refuses to proceed without it)
+- A GPU that Wolf supports (Intel, AMD, or NVIDIA)
+- NVIDIA users: `nvidia_drm` must load with `modeset=1`. See
+  [docs/FAQ.md](docs/FAQ.md) before installing — without modeset, Wolf will
+  black-screen or crash on stream start.
 
 ## Installation
 
-Head over the `PLUGINS` page on Unraid, `Install Plugin` tab, paste:
-```
-https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/gow.plg
-```
-and press `INSTALL`
+1. In the Unraid webGui, go to **Plugins → Install Plugin**.
+2. Paste the plugin URL and click **Install**:
+
+   ```
+   https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/gow.plg
+   ```
+
+3. After install completes, open **Settings → Games on Whales** to configure
+   your GPU and appdata path, then click **Deploy**.
+
+You should see output like:
 
 ```
 ╔════════════════════════════╗
@@ -26,9 +48,27 @@ and press `INSTALL`
 ╔══════════╗
 ║ Complete ║
 ╚══════════╝
-success!
-plugin: gow.plg installed
 ```
+
+## Configuration
+
+The Settings page (**Settings → Games on Whales**) covers:
+
+- **GPU selection** — multi-GPU systems get a picker; the chosen GPU is
+  passed through to the Wolf container.
+- **Appdata path** — where Wolf and Wolf Den persist their state. Defaults
+  to `/mnt/user/appdata/gow`.
+- **Deploy / Start / Stop / Update** — buttons that wrap the underlying
+  `docker compose` calls so you don't have to drop to the shell.
+
+Persistent udev rules and an auto-start hook are written to
+`/boot/config/go` so the stack comes back up after a reboot.
+
+## Pairing a Moonlight client
+
+Once the stack is running, point your Moonlight client at the Unraid
+server's IP. Wolf will surface a one-time PIN URL on the host; open it in a
+browser, paste the PIN your Moonlight client shows, and you're paired.
 
 ## Troubleshooting
 
@@ -36,6 +76,17 @@ See [docs/FAQ.md](docs/FAQ.md). NVIDIA users in particular should read the
 `nvidia_drm.modeset` section before reporting black-screen or crashed-Wolf
 issues.
 
-## Developer Notes
+## Support
 
-See [DEVELOPING.md](DEVELOPING.md)
+- **Forum thread (Unraid):** TODO — replace with link once the support
+  thread is opened.
+- **Discord:** https://discord.gg/kRGUDHNHt2
+- **Issues:** https://github.com/games-on-whales/unraid-plugin/issues
+
+## License
+
+[MIT](LICENSE).
+
+## Developer notes
+
+See [DEVELOPING.md](DEVELOPING.md).

--- a/unraid-ca/SUBMIT.md
+++ b/unraid-ca/SUBMIT.md
@@ -1,0 +1,72 @@
+# Community Applications submission checklist
+
+This folder holds the templates Unraid Community Applications scans when it
+indexes our repository:
+
+- [`ca_profile.xml`](./ca_profile.xml) — maintainer profile (icon + blurb)
+- [`gow.xml`](./gow.xml) — plugin template that points CA at `gow.plg`
+
+The submission portal is **https://ca.unraid.net/submit** ([builders guide](https://ca.unraid.net/submit/help/builders)).
+Submissions are reviewed by the CA moderation team within ~48h
+([Unraid Docs](https://docs.unraid.net/unraid-os/using-unraid-to/run-docker-containers/community-applications/)).
+
+## Manual steps left to do (only the maintainer can do these)
+
+### 1. Get an Unraid forum support thread in Plugin Support
+
+CA requires a dedicated support thread on `forums.unraid.net`. The
+[Plugin Support subforum](https://forums.unraid.net/forum/61-plugin-support/)
+**does not accept new threads from regular users** — only approved plugin
+authors and moderators can create top-level topics there. There are three
+paths, in priority order:
+
+**Option A (try first): submit to CA and let the moderator place the thread.**
+The submission portal at `ca.unraid.net/submit` is the current canonical
+flow; if the CA moderator (Squid / the CA team) approves the repo, they
+will typically create or place the Plugin Support thread on your behalf.
+If you go this route, just submit the repo with the placeholder
+`<Support>` URL pointing at the subforum index, and answer "support thread
+pending CA review" if a reviewer asks.
+
+**Option B: post in [General](https://forums.unraid.net/forum/77-general/) and
+ask a mod to move it.** General accepts new threads from any registered
+user. Title: `[PLUGIN] Games on Whales`. Body: short blurb, install URL
+(`https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/gow.plg`),
+link to the GitHub repo, link to [`docs/FAQ.md`](../docs/FAQ.md), and a
+call-out that NVIDIA users need `nvidia_drm.modeset=1`. Once posted, hit
+**Report** on your own first post and ask a moderator to move it to Plugin
+Support.
+
+**Option C: DM `@Squid`** (forum profile 10290) asking for a Plugin Support
+thread to be opened for an upcoming CA submission. Slowest but works if A
+and B stall.
+
+Whichever path, the end state is a URL like
+`https://forums.unraid.net/topic/NNNNNN-plugin-games-on-whales/`.
+
+### 2. Wire the forum URL into the plugin
+
+Once you have the thread URL, replace the placeholder in three places:
+
+- [`gow.plg`](../gow.plg) — `support="..."` attribute (currently the Discord URL)
+- [`unraid-ca/gow.xml`](./gow.xml) — `<Support>` element (currently points at
+  the subforum index, not a specific thread)
+- [`README.md`](../README.md) — the `Forum thread (Unraid):` TODO line
+
+Tag a new release (e.g. `2026.04.27`) so the bumped `support=` ships in
+the next install.
+
+### 3. Submit at https://ca.unraid.net/submit
+
+1. Sign in with an Unraid account that owns or is authorised for the
+   `games-on-whales/unraid-plugin` GitHub repository.
+2. **Add Repository** — paste `https://github.com/games-on-whales/unraid-plugin`.
+3. **Review** — the scanner will pick up `unraid-ca/ca_profile.xml` and
+   `unraid-ca/gow.xml`. Fix anything it flags.
+4. **Submit** — confirm and wait for moderator review (~48h).
+
+### 4. After approval
+
+The plugin will appear in CA search as **Games on Whales**. Future releases
+just need a new git tag — CA picks up the version from `gow.plg` on each
+indexer run, no resubmission needed unless template metadata changes.

--- a/unraid-ca/ca_profile.xml
+++ b/unraid-ca/ca_profile.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Maintainer>
+<Icon>https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/packages/settings-ui/root/usr/local/emhttp/plugins/gow/images/gow.png</Icon>
+<Profile>
+Games on Whales is an open-source project that lets you stream low-latency games and desktops from a server to your other devices over Moonlight. This profile hosts the official Unraid plugin, which deploys Wolf (the streaming server) and Wolf Den (the on-host launcher UI) via Docker Compose with Unraid-friendly defaults.
+</Profile>
+</Maintainer>

--- a/unraid-ca/gow.xml
+++ b/unraid-ca/gow.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Containers>
+<Plugin>True</Plugin>
+<PluginURL>https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/gow.plg</PluginURL>
+<PluginAuthor>Games on Whales</PluginAuthor>
+<Beta>False</Beta>
+<Category>GameServers: MediaApp:Other</Category>
+<Name>Games on Whales</Name>
+<Description>
+Stream games and desktops from your Unraid server to any Moonlight client over your LAN or the internet. Deploys Wolf (the streaming server) and Wolf Den (the on-host launcher UI) via Docker Compose, with a Settings page for picking a GPU, choosing your appdata path, and starting/stopping the stack. Requires Unraid 6.12 or newer and the Compose Manager plugin.
+</Description>
+<Project>https://github.com/games-on-whales/unraid-plugin</Project>
+<Overview>
+Games on Whales lets you run a low-latency game/desktop streaming host on your Unraid server. Connect from any [Moonlight](https://moonlight-stream.org) client, including Steam Deck, Apple TV, mobile, and desktop. The plugin handles the Docker Compose deployment of Wolf and Wolf Den, persists udev rules and an auto-start hook into /boot/config/go, and surfaces configuration through a Settings page under Settings > Games on Whales.
+
+NVIDIA users: please read the FAQ section on `nvidia_drm.modeset` before reporting black-screen issues.
+</Overview>
+<Support>https://forums.unraid.net/forum/61-plugin-support/</Support>
+<Icon>https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/packages/settings-ui/root/usr/local/emhttp/plugins/gow/images/gow.png</Icon>
+<Date>2026-04-26</Date>
+<MinVer>6.12.0</MinVer>
+<Requires>
+The "Compose Manager" plugin must be installed first. The plugin install will refuse to proceed without it.
+</Requires>
+<Screenshot>https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/packages/settings-ui/root/usr/local/emhttp/plugins/gow/images/gow.png</Screenshot>
+</Containers>


### PR DESCRIPTION
## Summary
- Adds `unraid-ca/ca_profile.xml` (maintainer profile) and `unraid-ca/gow.xml` (CA plugin template) so the repo is ready to submit at https://ca.unraid.net/submit.
- Tightens README with Status / Requirements / Installation / Configuration / Pairing / Support / License sections so the docs requirement (clear install + config + troubleshooting) is satisfied.
- Adds `unraid-ca/SUBMIT.md` checklist for the manual steps left (forum support thread, wiring its URL into `gow.plg` + `unraid-ca/gow.xml` + `README.md`, running the submission portal scan).

## Why
Unraid moved CA submission to a portal-based flow (`ca.unraid.net/submit`); a public repo containing `ca_profile.xml` + plugin XML is now the entry point. This PR is the minimum scaffolding that lets the CA scanner accept the repo. The `<Support>` URL in `gow.xml` and `support=` in `gow.plg` are placeholders pending the Plugin Support thread.

## Test plan
- [ ] `python3 -c "import xml.etree.ElementTree as ET; ET.parse('unraid-ca/ca_profile.xml'); ET.parse('unraid-ca/gow.xml')"` parses both files cleanly (verified locally).
- [ ] After merge, the CA submission scanner at https://ca.unraid.net/submit picks up `https://github.com/games-on-whales/unraid-plugin` without errors against the templates.
- [ ] Plugin install via existing `gow.plg` URL is unaffected (no `.plg` changes in this PR).