### PR TITLE
Fix issue 29 deployment and documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ clean rollback if anything goes wrong.
    ```
 
 3. After install completes, open **Settings → Games on Whales** to configure
-   your GPU and appdata path, then click **Deploy**.
+   your GPU and appdata path, then click **Install**.
 
 You should see output like:
 
@@ -58,7 +58,7 @@ The Settings page (**Settings → Games on Whales**) covers:
   passed through to the Wolf container.
 - **Appdata path** — where Wolf and Wolf Den persist their state. Defaults
   to `/mnt/user/appdata/gow`.
-- **Deploy / Start / Stop / Update** — buttons that wrap the underlying
+- **Install / Start / Stop / Update** — buttons that wrap the underlying
   `docker compose` calls so you don't have to drop to the shell.
 
 Persistent udev rules and an auto-start hook are written to
@@ -66,9 +66,15 @@ Persistent udev rules and an auto-start hook are written to
 
 ## Pairing a Moonlight client
 
-Once the stack is running, point your Moonlight client at the Unraid
-server's IP. Wolf will surface a one-time PIN URL on the host; open it in a
-browser, paste the PIN your Moonlight client shows, and you're paired.
+Once the stack is running, open Wolf Den's pairing page:
+
+```text
+http://<UNRAID_IP>:8080/Clients/Pairing
+```
+
+Add the Unraid server in Moonlight, then enter the PIN shown by Moonlight on the
+Wolf Den pairing page. The settings page also shows direct **Open Wolf Den** and
+**Pair Moonlight** links when Wolf Den is running.
 
 ## Troubleshooting
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -20,8 +20,20 @@ is off.
 
 1. Open **Tools > System Drivers** in the Unraid webGui.
 2. Find `nvidia_drm` in the driver list.
-3. Set the `modeset` parameter to `1` (or `Y`).
-4. Apply the change and reboot so the module reloads with the new parameter.
+3. Click the edit/config action for that row.
+4. In **Modprobe.d Config File**, enter exactly:
+
+   ```text
+   options nvidia_drm modeset=1
+   ```
+
+5. Apply the change and reboot so the module reloads with the new parameter.
+
+Unraid persists that editor content under
+`/boot/config/modprobe.d/nvidia_drm.conf` and copies it into `/etc/modprobe.d`
+at boot. If you prefer editing `syslinux.cfg`, the equivalent kernel command
+line option is `nvidia-drm.modeset=1`; do not put that kernel-command-line form
+inside the Modprobe.d Config File editor.
 
 ### References
 

--- a/gow.plg
+++ b/gow.plg
@@ -3,7 +3,7 @@
 <!ENTITY name      "gow">
 <!ENTITY author    "games-on-whales">
 <!ENTITY org       "games-on-whales">
-<!ENTITY version   "2026.05.08">
+<!ENTITY version   "2026.05.20">
 <!ENTITY launch    "Settings/gow">
 <!ENTITY gitURL    "https://raw.githubusercontent.com/&org;/unraid-plugin/main">
 <!ENTITY gitPkgURL "https://raw.githubusercontent.com/&org;/unraid-plugin/&version;">
@@ -25,6 +25,15 @@
 >
 
   <CHANGES>
+### 2026.05.20
+- Fix multi-GPU labels so each render node shows its own `lspci` device name instead of reusing another GPU's name
+- Remove stale NVIDIA driver-volume helper containers and explicitly delete the temporary helper container after populating the volume
+- Mount Wolf Den's writable app data and compatibility-tools directories so database state persists and compatibility tools can be provisioned
+- Keep the settings page in dashboard mode when a compose file or Wolf containers already exist, exposing Start/Stop/Update actions even if the deploy flag was not persisted
+- Let Start/Stop fall back to the fixed container names when an existing stack has no discoverable compose file
+- Show direct Wolf Den and Moonlight pairing URLs in the settings page and deployment output
+- Clarify the NVIDIA `nvidia_drm.modeset` FAQ with the exact Modprobe.d Config File content
+
 ### 2026.05.08
 - Settings page now nests under the User Utilities subsection of Settings (Menu="OtherSettings") instead of appearing as a peer of the top-level Settings categories
 - Restyle the settings page using Unraid's theme palette variables so text and cards render correctly under all four themes (white, azure, gray, black) — fixes invisible text on light themes

--- a/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
+++ b/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
@@ -66,6 +66,7 @@ function detect_gpus() {
         $real_path = realpath($device_dir);
         if ($real_path) $pci_slot = basename($real_path);
         if ($pci_slot) {
+            $lspci_out = [];
             exec("lspci -s " . escapeshellarg($pci_slot) . " -mm 2>/dev/null", $lspci_out);
             if (!empty($lspci_out[0])) {
                 // Format: "Slot" "Class" "Vendor" "Device" ...
@@ -117,6 +118,7 @@ function nvidia_drm_modeset_ok() {
 }
 
 define('FAQ_MODESET_URL', 'https://github.com/games-on-whales/unraid-plugin/blob/main/docs/FAQ.md#nvidia-wayland-support-nvidia_drmmodeset');
+define('WOLF_DEN_PAIRING_PATH', '/Clients/Pairing');
 
 // ── Action handlers ───────────────────────────────────────────────────────────
 
@@ -161,12 +163,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     } elseif ($action === 'start') {
         $compose = $cfg['APPDATA'] . '/docker-compose.yml';
-        exec("docker compose -f " . escapeshellarg($compose) . " up -d 2>&1", $out, $ret);
+        if (file_exists($compose)) {
+            exec("docker compose -f " . escapeshellarg($compose) . " up -d 2>&1", $out, $ret);
+        } else {
+            exec("docker start wolf wolf-den 2>&1", $out, $ret);
+        }
         $message = $ret === 0 ? 'Wolf started.' : 'Start failed: ' . implode("\n", $out);
 
     } elseif ($action === 'stop') {
         $compose = $cfg['APPDATA'] . '/docker-compose.yml';
-        exec("docker compose -f " . escapeshellarg($compose) . " down 2>&1", $out, $ret);
+        if (file_exists($compose)) {
+            exec("docker compose -f " . escapeshellarg($compose) . " down 2>&1", $out, $ret);
+        } else {
+            exec("docker stop wolf-den wolf 2>&1", $out, $ret);
+        }
         $message = $ret === 0 ? 'Wolf stopped.' : 'Stop failed: ' . implode("\n", $out);
 
     } elseif ($action === 'update') {
@@ -193,9 +203,15 @@ if ($deploying) {
     }
 }
 
-$deployed = ($cfg['DEPLOYED'] === 'true');
-$gpus     = detect_gpus();
-$ip       = local_ip();
+$gpus            = detect_gpus();
+$ip              = local_ip();
+$wolf_status     = container_status('wolf');
+$wolf_den_status = container_status('wolf-den');
+$compose_file    = $cfg['APPDATA'] . '/docker-compose.yml';
+$has_stack       = file_exists($compose_file) || $wolf_status !== 'not found' || $wolf_den_status !== 'not found';
+$deployed        = ($cfg['DEPLOYED'] === 'true') || $has_stack;
+$wolf_den_url    = $ip ? "http://{$ip}:8080" : '';
+$pairing_url     = $wolf_den_url ? $wolf_den_url . WOLF_DEN_PAIRING_PATH : '';
 ?>
 <!DOCTYPE html>
 <html>
@@ -278,8 +294,9 @@ $ip       = local_ip();
     <strong>NVIDIA Wayland not enabled.</strong>
     <code>/sys/module/nvidia_drm/parameters/modeset</code> is not <code>Y</code>,
     so Wolf will fail to compose or the client will see a black screen. Open
-    <strong>Tools &gt; System Drivers</strong>, set <code>nvidia_drm</code>
-    modeset to <code>1</code>, apply, and reboot.
+    <strong>Tools &gt; System Drivers</strong>, edit <code>nvidia_drm</code>,
+    set the Modprobe.d Config File to <code>options nvidia_drm modeset=1</code>,
+    apply, and reboot.
     <a href="<?= FAQ_MODESET_URL ?>" target="_blank" class="gow-msg-link">Details</a>.
   </div>
 <?php endif; ?>
@@ -289,18 +306,31 @@ $ip       = local_ip();
 
   <div class="gow-row">
     <span class="gow-label">Wolf</span>
-    <?= status_badge(container_status('wolf')) ?>
+    <?= status_badge($wolf_status) ?>
   </div>
   <div class="gow-row">
     <span class="gow-label">Wolf Den</span>
-    <?= status_badge(container_status('wolf-den')) ?>
-    <?php if (container_status('wolf-den') === 'running'): ?>
+    <?= status_badge($wolf_den_status) ?>
+    <?php if ($wolf_den_status === 'running' && $wolf_den_url): ?>
       &nbsp;
-      <a class="gow-btn-link" href="http://<?= htmlspecialchars($ip) ?>:8080" target="_blank">
+      <a class="gow-btn-link" href="<?= htmlspecialchars($wolf_den_url) ?>" target="_blank">
         Open Wolf Den &rarr;
+      </a>
+      <a class="gow-btn-link" href="<?= htmlspecialchars($pairing_url) ?>" target="_blank">
+        Pair Moonlight &rarr;
       </a>
     <?php endif; ?>
   </div>
+  <?php if ($wolf_den_url): ?>
+  <div class="gow-row">
+    <span class="gow-label">Wolf Den URL</span>
+    <a href="<?= htmlspecialchars($wolf_den_url) ?>" target="_blank"><?= htmlspecialchars($wolf_den_url) ?></a>
+  </div>
+  <div class="gow-row">
+    <span class="gow-label">Pairing URL</span>
+    <a href="<?= htmlspecialchars($pairing_url) ?>" target="_blank"><?= htmlspecialchars($pairing_url) ?></a>
+  </div>
+  <?php endif; ?>
 
   <div class="gow-row" style="margin-top:10px">
     <span class="gow-label">GPU</span>
@@ -390,8 +420,9 @@ $ip       = local_ip();
     <p class="gow-error">
       ⚠ NVIDIA detected but <code>nvidia_drm.modeset</code> is not enabled. Wolf's
       Wayland compositor will not work until you set it. Open
-      <strong>Tools &gt; System Drivers</strong>, set <code>nvidia_drm</code>
-      modeset to <code>1</code>, apply, and reboot before installing.
+      <strong>Tools &gt; System Drivers</strong>, edit <code>nvidia_drm</code>,
+      set the Modprobe.d Config File to <code>options nvidia_drm modeset=1</code>,
+      apply, and reboot before installing.
       <a href="<?= FAQ_MODESET_URL ?>" target="_blank" class="gow-msg-link">Details</a>.
     </p>
     <?php endif; ?>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -63,9 +63,16 @@ EOF
 
 setup_appdata_dirs() {
     info "Creating appdata directories at ${APPDATA}"
-    mkdir -p "${APPDATA}/cfg" "${APPDATA}/wolf-den" "${APPDATA}/covers" "${APPDATA}/steam"
-    # wolf-den drops privileges via gosu — dirs must be accessible by the container user
-    chmod 755 "${APPDATA}/wolf-den" "${APPDATA}/covers"
+    mkdir -p \
+        "${APPDATA}/cfg" \
+        "${APPDATA}/wolf-den" \
+        "${APPDATA}/covers" \
+        "${APPDATA}/steam" \
+        "${APPDATA}/compatibilitytools.d"
+    # wolf-den drops privileges to UID 1000 via gosu, so its writable dirs
+    # must be accessible before the app starts.
+    chown -R 1000:1000 "${APPDATA}/wolf-den" "${APPDATA}/covers" "${APPDATA}/compatibilitytools.d" 2>/dev/null || true
+    chmod 775 "${APPDATA}/wolf-den" "${APPDATA}/covers" "${APPDATA}/compatibilitytools.d"
 }
 
 # Wolf v1+ requires a uuid in config.toml. Older auto-generated configs (v0)
@@ -131,10 +138,12 @@ services:
     environment:
       - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60
+      - XDG_DATA_HOME=/app/wolf-den
     volumes:
       - wolf-socket:/tmp/sockets
       - ${APPDATA}/wolf-den:/app/wolf-den
       - ${APPDATA}/covers:/etc/wolf/covers
+      - ${APPDATA}/compatibilitytools.d:/etc/wolf/compatibilitytools.d
     ports:
       - "8080:8080"
     depends_on:
@@ -181,10 +190,12 @@ services:
     environment:
       - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60
+      - XDG_DATA_HOME=/app/wolf-den
     volumes:
       - wolf-socket:/tmp/sockets
       - ${APPDATA}/wolf-den:/app/wolf-den
       - ${APPDATA}/covers:/etc/wolf/covers
+      - ${APPDATA}/compatibilitytools.d:/etc/wolf/compatibilitytools.d
     ports:
       - "8080:8080"
     depends_on:
@@ -227,6 +238,7 @@ detect_nvidia_version() {
 build_nvidia_volume() {
     detect_nvidia_version
     info "NVIDIA driver version: ${NV_VERSION}"
+    cleanup_nvidia_driver_containers
 
     if docker volume inspect nvidia-driver-vol &>/dev/null; then
         info "NVIDIA driver volume already exists — skipping build"
@@ -239,11 +251,25 @@ build_nvidia_volume() {
         | docker build -t gow/nvidia-driver:latest -f - \
             --build-arg NV_VERSION="${NV_VERSION}" .
 
-    docker create --rm \
+    local cid
+    cid=$(docker create \
+        --label org.games-on-whales.unraid-plugin=nvidia-driver-volume \
         --mount source=nvidia-driver-vol,destination=/usr/nvidia \
-        gow/nvidia-driver:latest sh
+        gow/nvidia-driver:latest sh)
+    docker rm "$cid" >/dev/null
 
     info "NVIDIA driver volume ready"
+}
+
+cleanup_nvidia_driver_containers() {
+    local ids
+    ids=$(docker ps -aq \
+        --filter "ancestor=gow/nvidia-driver:latest" \
+        --filter "status=created" 2>/dev/null || true)
+    if [[ -n "$ids" ]]; then
+        info "Removing stale NVIDIA driver volume helper containers"
+        docker rm $ids >/dev/null 2>&1 || true
+    fi
 }
 
 # ── Boot persistence ──────────────────────────────────────────────────────────
@@ -295,11 +321,12 @@ cat <<EOF
 Games on Whales deployed successfully.
 
   Wolf Den:  http://${LOCAL_IP:-<HOST_IP>}:8080
+  Pairing:   http://${LOCAL_IP:-<HOST_IP>}:8080/Clients/Pairing
   Appdata:   ${APPDATA}
   GPU:       ${GPU_VENDOR} ${GPU_NAME:-} (${RENDER_NODE})
 
 To pair with Moonlight:
-  1. Open Wolf Den at http://${LOCAL_IP:-<HOST_IP>}:8080
+  1. Open Wolf Den pairing at http://${LOCAL_IP:-<HOST_IP>}:8080/Clients/Pairing
   2. Add this server in Moonlight: ${LOCAL_IP:-<HOST_IP>}
   3. Enter the PIN shown in Moonlight into Wolf Den
 ================================================================

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -31,7 +31,7 @@ detect_gpus() {
         name="Unknown"
         pci_slot=$(basename "$(readlink -f "$device_dir")" 2>/dev/null) || true
         if [[ -n "$pci_slot" ]] && command -v lspci &>/dev/null; then
-            name=$(lspci -s "$pci_slot" -mm 2>/dev/null | awk -F'"' '{print $6}') || true
+            name=$(lspci -s "$pci_slot" -mm 2>/dev/null | awk -F'"' 'NF >= 8 {print $8}') || true
             [[ -z "$name" ]] && name="Unknown"
         fi
 

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -2,7 +2,7 @@
 # vars.sh — shared environment for all GoW plugin scripts
 
 export GOW_NAME="gow"
-export GOW_VERSION="2026.05.08"
+export GOW_VERSION="2026.05.20"
 export GOW_ORG="games-on-whales"
 export GOW_PLUGIN="/boot/config/plugins/gow"
 export GOW_CFG="${GOW_PLUGIN}/gow.cfg"


### PR DESCRIPTION
## Summary
- fix multi-GPU labels and stale NVIDIA driver helper containers
- persist Wolf Den app/database and compatibility tool paths with writable permissions
- keep settings dashboard controls available for existing stacks and add explicit Wolf Den pairing links
- clarify install/pairing/modeset docs and bump plugin version to 2026.05.20

Fixes #29

## Verification
- bash -n scripts/install.sh
- bash -n scripts/deploy.sh
- bash -n scripts/vars.sh
- git diff --check

Note: php and xmllint are not installed in this environment, so PHP/XML lint could not be run locally.