### PR TITLE
Fix release-backed plugin update URL

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -95,13 +95,12 @@ During development, serve the `dist/` directory from your local HTTP server and 
 
 1. Update the `version` entity in `gow.plg` to today's date (`YYYY.MM.DD`).
 2. Update `GOW_VERSION` in `scripts/vars.sh` to match.
-3. Rebuild `settings-ui.txz` (see above) and update the hashes in `gow.plg`.
-4. Commit and push, then create a git tag matching the version:
+3. Commit and merge the release change, then create a git tag matching the version:
    ```sh
    git tag 2026.04.10
    git push origin 2026.04.10
    ```
-5. The `release` GitHub Actions workflow triggers automatically, builds the package, and creates a GitHub release with `settings-ui.txz`, its checksums, and `gow.plg` as release assets.
+4. The `release` GitHub Actions workflow triggers automatically, builds the package, and creates a GitHub release with `settings-ui.txz`, its checksums, and `gow.plg` as release assets. The moving install/update URL points at that latest release asset, so do not bump `version` without publishing the matching tag.
 
 ## Adding a new package
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ clean rollback if anything goes wrong.
 2. Paste the plugin URL and click **Install**:
 
    ```
-   https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/gow.plg
+   https://github.com/games-on-whales/unraid-plugin/releases/latest/download/gow.plg
    ```
 
 3. After install completes, open **Settings → Games on Whales** to configure

--- a/gow.plg
+++ b/gow.plg
@@ -3,12 +3,11 @@
 <!ENTITY name      "gow">
 <!ENTITY author    "games-on-whales">
 <!ENTITY org       "games-on-whales">
-<!ENTITY version   "2026.05.20">
+<!ENTITY version   "2026.05.21">
 <!ENTITY launch    "Settings/gow">
-<!ENTITY gitURL    "https://raw.githubusercontent.com/&org;/unraid-plugin/main">
 <!ENTITY gitPkgURL "https://raw.githubusercontent.com/&org;/unraid-plugin/&version;">
 <!ENTITY gitReleaseURL "https://github.com/&org;/unraid-plugin/releases/download/&version;">
-<!ENTITY pluginURL "&gitURL;/&name;.plg">
+<!ENTITY pluginURL "https://github.com/&org;/unraid-plugin/releases/latest/download/&name;.plg">
 <!ENTITY plugin    "/boot/config/plugins/&name;">
 <!ENTITY emhttp    "/usr/local/emhttp/plugins/&name;">
 <!ENTITY script_dir "&plugin;/scripts">
@@ -25,6 +24,9 @@
 >
 
   <CHANGES>
+### 2026.05.21
+- Point the moving plugin URL at the latest GitHub release asset instead of `main` so Unraid only advertises versions that have a matching `settings-ui.txz` package
+
 ### 2026.05.20
 - Fix multi-GPU labels so each render node shows its own `lspci` device name instead of reusing another GPU's name
 - Remove stale NVIDIA driver-volume helper containers and explicitly delete the temporary helper container after populating the volume

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -2,7 +2,7 @@
 # vars.sh — shared environment for all GoW plugin scripts
 
 export GOW_NAME="gow"
-export GOW_VERSION="2026.05.20"
+export GOW_VERSION="2026.05.21"
 export GOW_ORG="games-on-whales"
 export GOW_PLUGIN="/boot/config/plugins/gow"
 export GOW_CFG="${GOW_PLUGIN}/gow.cfg"

--- a/unraid-ca/SUBMIT.md
+++ b/unraid-ca/SUBMIT.md
@@ -31,7 +31,7 @@ pending CA review" if a reviewer asks.
 **Option B: post in [General](https://forums.unraid.net/forum/77-general/) and
 ask a mod to move it.** General accepts new threads from any registered
 user. Title: `[PLUGIN] Games on Whales`. Body: short blurb, install URL
-(`https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/gow.plg`),
+(`https://github.com/games-on-whales/unraid-plugin/releases/latest/download/gow.plg`),
 link to the GitHub repo, link to [`docs/FAQ.md`](../docs/FAQ.md), and a
 call-out that NVIDIA users need `nvidia_drm.modeset=1`. Once posted, hit
 **Report** on your own first post and ask a moderator to move it to Plugin

--- a/unraid-ca/gow.xml
+++ b/unraid-ca/gow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Containers>
 <Plugin>True</Plugin>
-<PluginURL>https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/gow.plg</PluginURL>
+<PluginURL>https://github.com/games-on-whales/unraid-plugin/releases/latest/download/gow.plg</PluginURL>
 <PluginAuthor>Games on Whales</PluginAuthor>
 <Beta>False</Beta>
 <Category>GameServers: MediaApp:Other</Category>
@@ -17,7 +17,7 @@ NVIDIA users: please read the FAQ section on `nvidia_drm.modeset` before reporti
 </Overview>
 <Support>https://forums.unraid.net/forum/61-plugin-support/</Support>
 <Icon>https://raw.githubusercontent.com/games-on-whales/unraid-plugin/main/packages/settings-ui/root/usr/local/emhttp/plugins/gow/images/gow.png</Icon>
-<Date>2026-04-26</Date>
+<Date>2026-05-21</Date>
 <MinVer>6.12.0</MinVer>
 <Requires>
 The "Compose Manager" plugin must be installed first. The plugin install will refuse to proceed without it.

--- a/utils/fmakepkg.sh
+++ b/utils/fmakepkg.sh
@@ -46,6 +46,8 @@ fi
 # I have put all the code into a function so that others can easily copy
 # and paste it into another script.
 fmakepkg() {
+  METADATA_PRUNE='( -name .codex -o -name .agents )'
+  TAR_EXCLUDES='--exclude=./.codex --exclude=./.agents'
 
   # Handle Slackware's makepkg options
   while [ 0 ]; do
@@ -78,7 +80,7 @@ fmakepkg() {
 
   # Reset permissions and ownership
   if [ "${SETPERMS:-y}" = "y" ]; then
-    find . -type d -exec chmod 755 {} \;
+    find . $METADATA_PRUNE -prune -o -type d -exec chmod 755 {} \;
     # Changing file ownership is an unofficial extension to makepkg
     TAROWNER="--group 0 --owner 0"
   else
@@ -109,9 +111,9 @@ fmakepkg() {
     *) echo "Unknown compression type" >&2 ; exit 1 ;;
   esac
   if [ -x /bin/tar-1.13 ]; then
-    tar-1.13 $TAROWNER -cvvf- . | $cmp > "$1"
+    tar-1.13 $TAR_EXCLUDES $TAROWNER -cvvf- . | $cmp > "$1"
   else
-    tar cvvf - . --format gnu --xform 'sx^\./\(.\)x\1x' --show-stored-names $TAROWNER | $cmp > "$1"
+    tar $TAR_EXCLUDES --format gnu --xform 'sx^\./\(.\)x\1x' --show-stored-names $TAROWNER -cvvf - . | $cmp > "$1"
   fi
   echo "Slackware package \"$1\" created."
 


### PR DESCRIPTION
Fixes #31.\n\nSummary:\n- bump the plugin release to 2026.05.21\n- point install/update metadata at the latest release asset instead of main\n- keep local agent metadata out of settings-ui packages\n\nChecks:\n- bash -n scripts/vars.sh scripts/preinstall.sh scripts/install.sh scripts/deploy.sh scripts/uninstall.sh scripts/update.sh utils/fmakepkg.sh\n- python3 XML parse for gow.plg and CA XML files\n- git diff --check\n- bash utils/fmakepkg.sh /tmp/settings-ui-2026.05.21.txz