### PR TITLE
Fix Wolf Den port binding and runtime cleanup

### DIFF
--- a/gow.plg
+++ b/gow.plg
@@ -3,7 +3,7 @@
 <!ENTITY name      "gow">
 <!ENTITY author    "games-on-whales">
 <!ENTITY org       "games-on-whales">
-<!ENTITY version   "2026.05.21a">
+<!ENTITY version   "2026.05.21b">
 <!ENTITY launch    "Settings/gow">
 <!ENTITY gitPkgURL "https://raw.githubusercontent.com/&org;/unraid-plugin/&version;">
 <!ENTITY gitReleaseURL "https://github.com/&org;/unraid-plugin/releases/download/&version;">
@@ -24,6 +24,10 @@
 >
 
   <CHANGES>
+### 2026.05.21b
+- Make Wolf Den listen on the configured host port directly instead of publishing container port `8080`
+- Remove WolfPulseAudio when the plugin stops, reconfigures, or uninstalls the Wolf stack
+
 ### 2026.05.21a
 - Allow same-day hotfix release tags such as `2026.05.21a`
 - Keep the install/update PLG URL on release assets so script downloads resolve from an existing tag

--- a/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
+++ b/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
@@ -115,6 +115,10 @@ function valid_tcp_port($port) {
         && (int)$port >= 1 && (int)$port <= 65535;
 }
 
+function cleanup_wolf_runtime_containers() {
+    exec('docker rm -f WolfPulseAudio >/dev/null 2>&1 || true');
+}
+
 // Wolf composes through Wayland; on NVIDIA this requires nvidia_drm.modeset=Y
 // or the client gets a black screen. See docs/FAQ.md.
 function nvidia_drm_modeset_ok() {
@@ -188,6 +192,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } else {
             exec("docker stop wolf-den wolf 2>&1", $out, $ret);
         }
+        cleanup_wolf_runtime_containers();
         $message = $ret === 0 ? 'Wolf stopped.' : 'Stop failed: ' . implode("\n", $out);
 
     } elseif ($action === 'update') {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,6 +25,7 @@ WOLF_DEN_PORT="${WOLF_DEN_PORT:-8080}"
 if [[ ! "$WOLF_DEN_PORT" =~ ^[0-9]+$ ]] || (( WOLF_DEN_PORT < 1 || WOLF_DEN_PORT > 65535 )); then
     err "Wolf Den port must be a TCP port between 1 and 65535"
 fi
+WOLF_DEN_LISTEN_URL="http://0.0.0.0:${WOLF_DEN_PORT}"
 
 GO_SCRIPT="/boot/config/go"
 COMPOSE_FILE="${APPDATA}/docker-compose.yml"
@@ -77,6 +78,17 @@ setup_appdata_dirs() {
     # must be accessible before the app starts.
     chown -R 1000:1000 "${APPDATA}/wolf-den" "${APPDATA}/covers" "${APPDATA}/compatibilitytools.d" 2>/dev/null || true
     chmod 775 "${APPDATA}/wolf-den" "${APPDATA}/covers" "${APPDATA}/compatibilitytools.d"
+}
+
+cleanup_wolf_runtime_containers() {
+    local container
+    for container in WolfPulseAudio; do
+        if docker inspect "$container" &>/dev/null; then
+            info "Removing Wolf runtime container ${container}"
+            docker rm -f "$container" >/dev/null 2>&1 \
+                || warn "Could not remove Wolf runtime container ${container}"
+        fi
+    done
 }
 
 # Wolf v1+ requires a uuid in config.toml. Older auto-generated configs (v0)
@@ -143,13 +155,13 @@ services:
       - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60
       - XDG_DATA_HOME=/app/wolf-den
+      - ASPNETCORE_URLS=${WOLF_DEN_LISTEN_URL}
     volumes:
       - wolf-socket:/tmp/sockets
       - ${APPDATA}/wolf-den:/app/wolf-den
       - ${APPDATA}/covers:/etc/wolf/covers
       - ${APPDATA}/compatibilitytools.d:/etc/wolf/compatibilitytools.d
-    ports:
-      - "${WOLF_DEN_PORT}:8080"
+    network_mode: host
     depends_on:
       - wolf
     restart: unless-stopped
@@ -195,13 +207,13 @@ services:
       - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60
       - XDG_DATA_HOME=/app/wolf-den
+      - ASPNETCORE_URLS=${WOLF_DEN_LISTEN_URL}
     volumes:
       - wolf-socket:/tmp/sockets
       - ${APPDATA}/wolf-den:/app/wolf-den
       - ${APPDATA}/covers:/etc/wolf/covers
       - ${APPDATA}/compatibilitytools.d:/etc/wolf/compatibilitytools.d
-    ports:
-      - "${WOLF_DEN_PORT}:8080"
+    network_mode: host
     depends_on:
       - wolf
     restart: unless-stopped
@@ -296,6 +308,7 @@ EOF
 if [[ -f "$COMPOSE_FILE" ]]; then
     info "Stopping existing stack for reconfiguration"
     docker compose -f "$COMPOSE_FILE" down 2>/dev/null || true
+    cleanup_wolf_runtime_containers
 fi
 
 install_udev_rules

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -21,6 +21,11 @@ if [[ -f "$COMPOSE_FILE" ]]; then
     docker compose -f "$COMPOSE_FILE" down 2>/dev/null || warn "Could not stop containers cleanly"
 fi
 
+if docker inspect WolfPulseAudio &>/dev/null; then
+    info "Removing Wolf runtime container WolfPulseAudio"
+    docker rm -f WolfPulseAudio >/dev/null 2>&1 || warn "Could not remove WolfPulseAudio"
+fi
+
 # Remove marker blocks from /boot/config/go
 remove_go_block() {
     local marker="$1"

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -2,7 +2,7 @@
 # vars.sh — shared environment for all GoW plugin scripts
 
 export GOW_NAME="gow"
-export GOW_VERSION="2026.05.21a"
+export GOW_VERSION="2026.05.21b"
 export GOW_ORG="games-on-whales"
 export GOW_PLUGIN="/boot/config/plugins/gow"
 export GOW_CFG="${GOW_PLUGIN}/gow.cfg"


### PR DESCRIPTION
## Summary
- Make Wolf Den run on host networking and set ASPNETCORE_URLS to the configured Wolf Den port, removing the Docker publish path that could still bind host port 8080.
- Best-effort remove the known WolfPulseAudio runtime container when stopping, reconfiguring, or uninstalling the stack.
- Bump the plugin hotfix version to 2026.05.21b.

## Verification
- bash -n scripts/deploy.sh scripts/install.sh scripts/uninstall.sh scripts/update.sh scripts/preinstall.sh scripts/vars.sh
- git diff --check

PHP and XML linters were not available in this environment.

Fixes follow-up reports from #33.