### PR TITLE
Fix GoW reboot startup and mDNS warning

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -53,9 +53,9 @@ plugin install http://<your-dev-machine-ip>:8888/gow.plg
 
 | Script | When it runs | What it does |
 |---|---|---|
-| `preinstall.sh` | Plugin install | Unraid version, Docker, NVIDIA driver plugin, network checks |
+| `preinstall.sh` | Plugin install / boot replay | Unraid version check, plus non-fatal Docker, NVIDIA driver plugin, and network warnings |
 | `install.sh` | Plugin install | GPU detection, writes `gow.cfg`, installs `settings-ui.txz` |
-| `deploy.sh` | User clicks Install in UI | udev rules, appdata dirs, `docker-compose.yml`, containers, boot hooks |
+| `deploy.sh` | User clicks Install in UI | udev rules, appdata dirs, `docker-compose.yml`, containers, retrying boot hook |
 | `uninstall.sh` | Plugin remove | Stops containers, cleans `/boot/config/go`, removes udev rules |
 | `update.sh` | User clicks Update in UI | `docker compose pull && up -d` |
 | `vars.sh` | Sourced by all scripts | Shared env vars (`GOW_CFG`, `GOW_PLUGIN`, `DEFAULT_APPDATA`, …) |

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -40,3 +40,30 @@ inside the Modprobe.d Config File editor.
 - Unraid forum thread: https://forums.unraid.net/topic/98978-plugin-nvidia-driver/page/164/#findComment-1425257
 - Short summary: "for Wayland support, you need to set `nvidia_drm` modeset
   in Tools > System Drivers for your driver, then restart."
+
+## Moonlight discovery and mDNS/Avahi warnings
+
+Wolf advertises the Moonlight service with mDNS on UDP port 5353. Unraid also
+commonly runs `avahi-daemon` on the same port. When both are active, Avahi may
+log a warning like:
+
+```text
+Detected another IPv4 mDNS stack running on this host.
+```
+
+This does not normally stop the GoW plugin or Wolf containers from starting,
+but it can make Moonlight automatic discovery unreliable.
+
+### Check
+
+```bash
+ss -ulpn | grep 5353
+```
+
+If the output shows both `avahi-daemon` and `wolf`, discovery may be flaky.
+
+### Workaround
+
+Use the direct pairing URL shown on the GoW settings page, or manually add the
+Unraid server IP in Moonlight. Do not disable Unraid's Avahi service unless you
+understand the impact on other Unraid network discovery features.

--- a/gow.plg
+++ b/gow.plg
@@ -3,7 +3,7 @@
 <!ENTITY name      "gow">
 <!ENTITY author    "games-on-whales">
 <!ENTITY org       "games-on-whales">
-<!ENTITY version   "2026.05.21a">
+<!ENTITY version   "2026.05.22">
 <!ENTITY launch    "Settings/gow">
 <!ENTITY gitPkgURL "https://raw.githubusercontent.com/&org;/unraid-plugin/&version;">
 <!ENTITY gitReleaseURL "https://github.com/&org;/unraid-plugin/releases/download/&version;">
@@ -24,6 +24,12 @@
 >
 
   <CHANGES>
+### 2026.05.22
+- Make plugin boot replay tolerant of Docker, network, and NVIDIA driver services still coming up during Unraid startup
+- Replace the immediate `/boot/config/go` compose start with a retrying autostart hook that waits for Docker and GPU device nodes
+- Generate NVIDIA compose device entries from existing `/dev/nvidia*` nodes so older cards do not fail on absent optional devices
+- Warn when Avahi and Wolf are both bound to UDP 5353, which can make Moonlight mDNS discovery unreliable
+
 ### 2026.05.21a
 - Allow same-day hotfix release tags such as `2026.05.21a`
 - Keep the install/update PLG URL on release assets so script downloads resolve from an existing tag

--- a/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
+++ b/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
@@ -123,7 +123,20 @@ function nvidia_drm_modeset_ok() {
     return trim(@file_get_contents($path)) === 'Y';
 }
 
+function has_mdns_conflict() {
+    exec("ss -H -ulpn 2>/dev/null", $out);
+    $has_avahi = false;
+    $has_wolf = false;
+    foreach ($out as $line) {
+        if (strpos($line, ':5353') === false) continue;
+        if (strpos($line, 'avahi-daemon') !== false) $has_avahi = true;
+        if (strpos($line, '"wolf"') !== false || strpos($line, 'users:((wolf,') !== false) $has_wolf = true;
+    }
+    return $has_avahi && $has_wolf;
+}
+
 define('FAQ_MODESET_URL', 'https://github.com/games-on-whales/unraid-plugin/blob/main/docs/FAQ.md#nvidia-wayland-support-nvidia_drmmodeset');
+define('FAQ_MDNS_URL', 'https://github.com/games-on-whales/unraid-plugin/blob/main/docs/FAQ.md#moonlight-discovery-and-mdnsavahi-warnings');
 define('WOLF_DEN_PAIRING_PATH', '/Clients/Pairing');
 
 // ── Action handlers ───────────────────────────────────────────────────────────
@@ -225,6 +238,7 @@ $deployed        = !$setup_mode && (($cfg['DEPLOYED'] === 'true') || $has_stack)
 $wolf_den_port   = valid_tcp_port($cfg['WOLF_DEN_PORT']) ? $cfg['WOLF_DEN_PORT'] : '8080';
 $wolf_den_url    = $ip ? "http://{$ip}:{$wolf_den_port}" : '';
 $pairing_url     = $wolf_den_url ? $wolf_den_url . WOLF_DEN_PAIRING_PATH : '';
+$mdns_conflict   = $deployed && has_mdns_conflict();
 ?>
 <!DOCTYPE html>
 <html>
@@ -257,6 +271,8 @@ $pairing_url     = $wolf_den_url ? $wolf_den_url . WOLF_DEN_PAIRING_PATH : '';
   .gow-msg       { padding: 10px 14px; border-radius: 5px; margin-bottom: 14px; }
   .gow-msg.ok    { background: var(--green-100); border: 1px solid var(--green-800); color: var(--green-800); }
   .gow-msg.err   { background: var(--red-100);   border: 1px solid var(--red-800);   color: var(--red-800); }
+  .gow-msg.warn  { background: var(--mild-background-color);
+                   border: 1px solid var(--orange-300); color: var(--text-color); }
   .gow-msg .gow-msg-link { color: inherit; text-decoration: underline; }
   .gow-warn      { color: var(--orange-300); margin-top: 12px; }
   .gow-error     { color: var(--red-800);    margin-top: 12px; }
@@ -311,6 +327,15 @@ $pairing_url     = $wolf_den_url ? $wolf_den_url . WOLF_DEN_PAIRING_PATH : '';
     set the Modprobe.d Config File to <code>options nvidia_drm modeset=1</code>,
     apply, and reboot.
     <a href="<?= FAQ_MODESET_URL ?>" target="_blank" class="gow-msg-link">Details</a>.
+  </div>
+<?php endif; ?>
+
+<?php if ($mdns_conflict): ?>
+  <div class="gow-msg warn">
+    <strong>Moonlight discovery conflict detected.</strong>
+    Avahi and Wolf are both listening on UDP 5353, so automatic discovery may be unreliable.
+    Use the pairing link or add this server by IP in Moonlight if it does not appear.
+    <a href="<?= FAQ_MDNS_URL ?>" target="_blank" class="gow-msg-link">Details</a>.
   </div>
 <?php endif; ?>
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -101,6 +101,9 @@ ensure_wolf_uuid() {
 # ── Docker Compose ────────────────────────────────────────────────────────────
 
 write_compose_nvidia() {
+    local nvidia_devices
+    nvidia_devices="$(nvidia_device_entries)"
+
     cat > "$COMPOSE_FILE" <<YAML
 services:
   wolf:
@@ -124,13 +127,7 @@ services:
       - /dev/dri
       - /dev/uinput
       - /dev/uhid
-      - /dev/nvidia-uvm
-      - /dev/nvidia-uvm-tools
-      - /dev/nvidia-caps/nvidia-cap1
-      - /dev/nvidia-caps/nvidia-cap2
-      - /dev/nvidiactl
-      - /dev/nvidia0
-      - /dev/nvidia-modeset
+${nvidia_devices}
     device_cgroup_rules:
       - 'c 13:* rmw'
     network_mode: host
@@ -159,6 +156,19 @@ volumes:
     external: true
   wolf-socket:
 YAML
+}
+
+nvidia_device_entries() {
+    local dev
+    for dev in \
+        /dev/nvidiactl \
+        /dev/nvidia[0-9]* \
+        /dev/nvidia-modeset \
+        /dev/nvidia-uvm \
+        /dev/nvidia-uvm-tools \
+        /dev/nvidia-caps/nvidia-cap*; do
+        [[ -e "$dev" ]] && printf '      - %s\n' "$dev"
+    done
 }
 
 write_compose_standard() {
@@ -280,14 +290,56 @@ cleanup_nvidia_driver_containers() {
 
 install_autostart() {
     local marker="# GoW docker-compose"
-    if ! grep -qF "$marker" "$GO_SCRIPT" 2>/dev/null; then
+    local end_marker="# End GoW docker-compose"
+    local marker_re="${marker//\//\\/}"
+    local end_marker_re="${end_marker//\//\\/}"
+    if grep -qF "$marker" "$GO_SCRIPT" 2>/dev/null; then
+        info "Updating Wolf auto-start in /boot/config/go"
+        if grep -qF "$end_marker" "$GO_SCRIPT" 2>/dev/null; then
+            sed -i "/${marker_re}/,/${end_marker_re}/d" "$GO_SCRIPT"
+        else
+            sed -i "/${marker_re}/,/^$/d" "$GO_SCRIPT"
+        fi
+    else
         info "Adding Wolf auto-start to /boot/config/go"
-        cat >> "$GO_SCRIPT" <<EOF
+    fi
+
+    cat >> "$GO_SCRIPT" <<EOF
 
 ${marker}
-docker compose -f ${COMPOSE_FILE} up -d &
-EOF
+(
+  GOW_COMPOSE_FILE='${COMPOSE_FILE}'
+  GOW_RENDER_NODE='${RENDER_NODE}'
+  GOW_GPU_VENDOR='${GPU_VENDOR}'
+  GOW_AUTOSTART_LOG='/tmp/gow-autostart.log'
+
+  gow_nvidia_gpu_ready() {
+    for dev in /dev/nvidia[0-9]*; do
+      [ -e "\$dev" ] && return 0
+    done
+    return 1
+  }
+
+  gow_devices_ready() {
+    [ -z "\$GOW_RENDER_NODE" ] || [ -e "\$GOW_RENDER_NODE" ] || return 1
+    if [ "\$GOW_GPU_VENDOR" = "NVIDIA" ]; then
+      [ -e /dev/nvidiactl ] && gow_nvidia_gpu_ready && [ -e /dev/nvidia-uvm ] || return 1
     fi
+    return 0
+  }
+
+  for i in \$(seq 1 60); do
+    if docker info >/dev/null 2>&1 && [ -f "\$GOW_COMPOSE_FILE" ] && gow_devices_ready; then
+      docker compose -f "\$GOW_COMPOSE_FILE" up -d >"\$GOW_AUTOSTART_LOG" 2>&1
+      exit
+    fi
+    sleep 5
+  done
+
+  echo "GoW auto-start timed out waiting for Docker, GPU devices, or \$GOW_COMPOSE_FILE" >"\$GOW_AUTOSTART_LOG"
+) &
+${end_marker}
+EOF
 }
 
 # ── Main ──────────────────────────────────────────────────────────────────────

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# preinstall.sh — precondition checks before installing the GoW plugin
+# preinstall.sh — boot-safe precondition checks before installing the GoW plugin
 
 source "$(dirname "$0")/vars.sh"
 
@@ -25,32 +25,27 @@ check_unraid_version() {
 
 check_docker() {
     if ! docker info &>/dev/null; then
-        err "Docker is not running. Enable Docker in Settings > Docker and try again."
+        warn "Docker is not running yet. Enable Docker before deploying Wolf from the settings page."
+        return
     fi
     info "Docker OK"
 }
 
 check_nvidia() {
-    local has_nvidia=false has_other=false driver
+    local has_nvidia=false driver
 
     for node in /sys/class/drm/renderD*/device/driver; do
         [[ -e "$node" ]] || continue
         driver=$(basename "$(readlink "$node")")
         if [[ "$driver" == "nvidia" ]]; then
             has_nvidia=true
-        else
-            has_other=true
         fi
     done
 
     if [[ "$has_nvidia" == "true" ]]; then
         if [[ ! -f /boot/config/plugins/nvidia-driver.plg ]]; then
-            if [[ "$has_other" == "true" ]]; then
-                warn "NVIDIA GPU detected but the Nvidia-Driver plugin is not installed."
-                warn "If you want to use the NVIDIA GPU with Wolf, install Nvidia-Driver from Community Applications first."
-            else
-                err "NVIDIA GPU detected but the Nvidia-Driver plugin is not installed. Install it from Community Applications and try again."
-            fi
+            warn "NVIDIA GPU detected but the Nvidia-Driver plugin is not installed."
+            warn "If you want to use the NVIDIA GPU with Wolf, install Nvidia-Driver from Community Applications first."
         else
             info "NVIDIA driver plugin OK"
         fi
@@ -59,11 +54,11 @@ check_nvidia() {
 
 check_network() {
     info "Checking network connectivity..."
-    for i in {1..15}; do
-        ping -c1 -W2 ghcr.io &>/dev/null && { info "Network OK"; return 0; }
-        sleep 2
-    done
-    err "Cannot reach ghcr.io after 30 seconds. Check network connectivity."
+    if ping -c1 -W2 ghcr.io &>/dev/null; then
+        info "Network OK"
+    else
+        warn "Cannot reach ghcr.io right now. Image pulls may fail until network connectivity is available."
+    fi
 }
 
 check_unraid_version

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -26,8 +26,16 @@ remove_go_block() {
     local marker="$1"
     if grep -qF "$marker" "$GO_SCRIPT" 2>/dev/null; then
         info "Removing '${marker}' from /boot/config/go"
-        # Delete from marker line through the following blank line (the block we appended)
-        sed -i "/$(echo "$marker" | sed 's|/|\\/|g')/,/^$/d" "$GO_SCRIPT"
+        # Newer blocks have an explicit end marker; older blocks ended at the
+        # following blank line.
+        local end_marker="# End ${marker#\# }"
+        local marker_re="${marker//\//\\/}"
+        local end_marker_re="${end_marker//\//\\/}"
+        if grep -qF "$end_marker" "$GO_SCRIPT" 2>/dev/null; then
+            sed -i "/${marker_re}/,/${end_marker_re}/d" "$GO_SCRIPT"
+        else
+            sed -i "/${marker_re}/,/^$/d" "$GO_SCRIPT"
+        fi
     fi
 }
 

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -2,7 +2,7 @@
 # vars.sh — shared environment for all GoW plugin scripts
 
 export GOW_NAME="gow"
-export GOW_VERSION="2026.05.21a"
+export GOW_VERSION="2026.05.22"
 export GOW_ORG="games-on-whales"
 export GOW_PLUGIN="/boot/config/plugins/gow"
 export GOW_CFG="${GOW_PLUGIN}/gow.cfg"


### PR DESCRIPTION
## Summary
- Make plugin boot replay tolerant of Docker, network, and NVIDIA driver services still coming up during Unraid startup.
- Replace the immediate /boot/config/go compose start with a retrying autostart hook that waits for Docker and GPU device nodes.
- Generate NVIDIA compose device entries from existing /dev/nvidia* nodes for older or variant NVIDIA layouts.
- Warn when Avahi and Wolf are both bound to UDP 5353 because Moonlight discovery may be unreliable.
- Bump plugin metadata to 2026.05.22.

## Verification
- bash -n scripts/preinstall.sh scripts/install.sh scripts/deploy.sh scripts/update.sh scripts/uninstall.sh scripts/vars.sh
- git diff --check
- perl -MXML::Parser -e 'XML::Parser->new->parsefile("gow.plg"); print "gow.plg XML OK\\n"'\n\nRelated issue: #37. Leaving the issue open for reporter confirmation.