### PR TITLE
Fix GoW appdata host path mapping

### DIFF
--- a/gow.plg
+++ b/gow.plg
@@ -3,7 +3,7 @@
 <!ENTITY name      "gow">
 <!ENTITY author    "games-on-whales">
 <!ENTITY org       "games-on-whales">
-<!ENTITY version   "2026.05.23">
+<!ENTITY version   "2026.05.25">
 <!ENTITY launch    "Settings/gow">
 <!ENTITY gitPkgURL "https://raw.githubusercontent.com/&org;/unraid-plugin/&version;">
 <!ENTITY gitReleaseURL "https://github.com/&org;/unraid-plugin/releases/download/&version;">
@@ -24,6 +24,10 @@
 >
 
   <CHANGES>
+### 2026.05.25
+- Mount the selected appdata root at `/etc/wolf` so Wolf-created app containers write state under the chosen appdata path instead of host `/etc`
+- Copy any existing host `/etc/wolf` data into the selected appdata path without overwriting newer appdata files
+
 ### 2026.05.23
 - Add Wolf network settings to the GUI: host, bridge, or a custom Docker network such as `br0`
 - Publish Wolf's default Moonlight ports when bridge mode is selected

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -115,6 +115,15 @@ setup_appdata_dirs() {
     chmod 775 "${APPDATA}/wolf-den" "${APPDATA}/covers" "${APPDATA}/compatibilitytools.d"
 }
 
+migrate_legacy_etc_wolf() {
+    local legacy="/etc/wolf"
+    [[ "$APPDATA" != "$legacy" && -d "$legacy" && ! -L "$legacy" ]] || return 0
+
+    info "Migrating existing Wolf data from ${legacy} into ${APPDATA}"
+    cp -a -n "${legacy}/." "${APPDATA}/" 2>/dev/null \
+        || warn "Could not migrate all existing Wolf data from ${legacy}"
+}
+
 cleanup_wolf_runtime_containers() {
     local container="WolfPulseAudio"
     if docker inspect "$container" &>/dev/null; then
@@ -213,8 +222,7 @@ YAML
     write_wolf_network_env
     cat <<YAML
     volumes:
-      - ${APPDATA}/cfg:/etc/wolf/cfg:rw
-      - ${APPDATA}/steam:/etc/wolf/steam:rw
+      - ${APPDATA}:/etc/wolf:rw
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - /dev/:/dev/:rw
       - /run/udev:/run/udev:rw
@@ -242,9 +250,8 @@ YAML
       - ASPNETCORE_URLS=${WOLF_DEN_LISTEN_URL}
     volumes:
       - wolf-socket:/tmp/sockets
+      - ${APPDATA}:/etc/wolf:rw
       - ${APPDATA}/wolf-den:/app/wolf-den
-      - ${APPDATA}/covers:/etc/wolf/covers
-      - ${APPDATA}/compatibilitytools.d:/etc/wolf/compatibilitytools.d
     network_mode: host
     depends_on:
       - wolf
@@ -288,8 +295,7 @@ YAML
     write_wolf_network_env
     cat <<YAML
     volumes:
-      - ${APPDATA}/cfg:/etc/wolf/cfg:rw
-      - ${APPDATA}/steam:/etc/wolf/steam:rw
+      - ${APPDATA}:/etc/wolf:rw
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - /dev/:/dev/:rw
       - /run/udev:/run/udev:rw
@@ -315,9 +321,8 @@ YAML
       - ASPNETCORE_URLS=${WOLF_DEN_LISTEN_URL}
     volumes:
       - wolf-socket:/tmp/sockets
+      - ${APPDATA}:/etc/wolf:rw
       - ${APPDATA}/wolf-den:/app/wolf-den
-      - ${APPDATA}/covers:/etc/wolf/covers
-      - ${APPDATA}/compatibilitytools.d:/etc/wolf/compatibilitytools.d
     network_mode: host
     depends_on:
       - wolf
@@ -464,6 +469,7 @@ fi
 
 install_udev_rules
 setup_appdata_dirs
+migrate_legacy_etc_wolf
 ensure_wolf_uuid
 write_compose
 

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -2,7 +2,7 @@
 # vars.sh — shared environment for all GoW plugin scripts
 
 export GOW_NAME="gow"
-export GOW_VERSION="2026.05.23"
+export GOW_VERSION="2026.05.25"
 export GOW_ORG="games-on-whales"
 export GOW_PLUGIN="/boot/config/plugins/gow"
 export GOW_CFG="${GOW_PLUGIN}/gow.cfg"


### PR DESCRIPTION
## Summary
- mount the selected appdata root at /etc/wolf so Wolf can map app-container state back to the chosen host path
- migrate any existing host /etc/wolf data into appdata without overwriting existing appdata files
- bump plugin metadata to 2026.05.25 for release tagging

Refs #40

## Verification
- bash -n scripts/preinstall.sh scripts/install.sh scripts/deploy.sh scripts/update.sh scripts/uninstall.sh scripts/utils.sh scripts/vars.sh
- generated compose writer smoke check for standard and NVIDIA mappings