### PR TITLE
Rebuild NVIDIA driver volume when host driver version changes (#47)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -364,14 +364,24 @@ detect_nvidia_version() {
     err "Cannot determine NVIDIA driver version. Is the NVIDIA driver plugin active?"
 }
 
+NV_VERSION_LABEL="org.games-on-whales.nv_version"
+
 build_nvidia_volume() {
     detect_nvidia_version
     info "NVIDIA driver version: ${NV_VERSION}"
     cleanup_nvidia_driver_containers
 
     if docker volume inspect nvidia-driver-vol &>/dev/null; then
-        info "NVIDIA driver volume already exists — skipping build"
-        return
+        local built_version
+        built_version=$(docker volume inspect nvidia-driver-vol \
+            --format "{{ index .Labels \"${NV_VERSION_LABEL}\" }}" 2>/dev/null) || true
+        if [[ "$built_version" == "$NV_VERSION" ]]; then
+            info "NVIDIA driver volume already built for ${NV_VERSION} — skipping build"
+            return
+        fi
+        info "NVIDIA driver volume was built for '${built_version:-unknown}' but host driver is ${NV_VERSION} — rebuilding"
+        docker volume rm nvidia-driver-vol >/dev/null 2>&1 \
+            || err "Failed to remove stale nvidia-driver-vol. Stop containers using it and retry."
     fi
 
     info "Building NVIDIA driver volume — this may take several minutes..."
@@ -379,6 +389,10 @@ build_nvidia_volume() {
         "https://raw.githubusercontent.com/games-on-whales/gow/master/images/nvidia-driver/Dockerfile" \
         | docker build -t gow/nvidia-driver:latest -f - \
             --build-arg NV_VERSION="${NV_VERSION}" .
+
+    docker volume create \
+        --label "${NV_VERSION_LABEL}=${NV_VERSION}" \
+        nvidia-driver-vol >/dev/null
 
     local cid
     cid=$(docker create \


### PR DESCRIPTION
## Problem

Closes the root cause described in #47.

The `nvidia-driver-vol` Docker volume bakes in the NVIDIA userspace driver libraries for a specific driver version at build time (`--build-arg NV_VERSION`). `build_nvidia_volume()` only checked whether the volume *existed*, so after a host driver upgrade (the reporter went 580 → 610) the volume was never rebuilt. The container kept serving the old 580 userspace libs against the new 610 kernel module.

NVIDIA requires the userspace libs to exactly match the loaded kernel module, so the mismatch fails EGL initialization:

```
[EGL] BAD_ALLOC eglQueryDevicesEXT: Failed to allocate device list
[EGL] NOT_INITIALIZED ... eglInitialize
```

which cascades into `WaylandDisplay::get_render_device` failing and Wolf's wayland GStreamer source panicking with `RecvError`.

Removing Docker/images did not help the reporter because the named volume (and `gow/nvidia-driver:latest` image) survived, so the rebuild stayed skipped.

## Fix

- Stamp the volume with the driver version it was built for via a Docker volume label (`org.games-on-whales.nv_version`).
- Skip the build only when the label matches the currently-detected host driver version.
- Otherwise log the mismatch, `docker volume rm` the stale volume, and rebuild + re-label it.

The main flow already runs `docker compose down` before `build_nvidia_volume`, so the volume is free when removed; if removal fails it errors with a clear message instead of silently continuing.

Existing users have an unlabeled volume, so they get a one-time rebuild on next deploy — which is exactly the self-heal #47 needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)