### PR TITLE
Bundle helper scripts in the versioned txz so plugin updates refresh them

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -79,6 +79,15 @@ jobs:
             git push origin "$VERSION"
           fi
 
+      - name: Stage helper scripts into the package
+        run: |
+          # Bundle the scripts inside the versioned .txz so they refresh on every
+          # plugin update (a constant-path <FILE> download would be cached stale).
+          dest=packages/settings-ui/root/boot/config/plugins/gow/scripts
+          mkdir -p "$dest"
+          cp scripts/*.sh "$dest/"
+          chmod +x "$dest"/*.sh
+
       - name: Build settings-ui package
         run: |
           chmod +x utils/fmakepkg.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 package-dist/
 packages/settings-ui/dist/
 
+# Helper scripts are staged here at build time from scripts/ (single source of
+# truth); never commit the copies.
+packages/settings-ui/root/boot/
+

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -4,7 +4,9 @@
 
 The plugin has two installation phases:
 
-1. **Phase 1 (headless, during plugin install)** — `preinstall.sh` runs checks, `install.sh` detects GPUs and writes `/boot/config/plugins/gow/gow.cfg`, and the `settings-ui` package is installed to register the emhttp page.
+1. **Phase 1 (headless, during plugin install)** — `gow.plg` installs the `settings-ui` package, which ships both the emhttp page and all helper scripts. It then runs `preinstall.sh` (checks) and `install.sh` (GPU detection, writes `/boot/config/plugins/gow/gow.cfg`).
+
+   The helper scripts are bundled inside the version-stamped `settings-ui.txz` rather than downloaded as individual `<FILE>` entries. Unraid caches constant-path `<FILE>` downloads and does not refresh them on update unless their MD5 changes, so loose scripts went stale on in-place updates. The `.txz` filename embeds the version, so Unraid always re-fetches it.
 2. **Phase 2 (user-triggered, via the settings page)** — the user opens Settings > Games on Whales, picks a GPU and appdata path, and clicks Install. This calls `deploy.sh`, which writes udev rules, generates `docker-compose.yml`, builds the NVIDIA driver volume if needed, and starts Wolf + Wolf Den.
 
 ## Prerequisites
@@ -28,19 +30,15 @@ Your files will be available at `http://<your-dev-machine-ip>:8888/`.
 
 ## Installing the development version
 
-Open `gow.plg` and temporarily change `gitPkgURL` to point at your local server:
+Build the package first (see [Building the settings-ui package](#building-the-settings-ui-package)) so your script changes are bundled in the `.txz` — they are no longer served loose.
 
-```xml
-<!ENTITY gitPkgURL "http://<your-dev-machine-ip>:8888">
-```
-
-Also change `gitReleaseURL` to the same base with `/packages/settings-ui/dist`:
+Open `gow.plg` and temporarily change `gitReleaseURL` to point at your local server's `dist/` directory:
 
 ```xml
 <!ENTITY gitReleaseURL "http://<your-dev-machine-ip>:8888/packages/settings-ui/dist">
 ```
 
-> Do not commit these changes. Revert before pushing.
+> Do not commit this change. Revert before pushing.
 
 Then on your Unraid server:
 
@@ -54,11 +52,13 @@ plugin install http://<your-dev-machine-ip>:8888/gow.plg
 | Script | When it runs | What it does |
 |---|---|---|
 | `preinstall.sh` | Plugin install / boot replay | Unraid version check, plus non-fatal Docker, NVIDIA driver plugin, and network warnings |
-| `install.sh` | Plugin install | GPU detection, writes `gow.cfg`, installs `settings-ui.txz` |
+| `install.sh` | Plugin install | GPU detection, writes `gow.cfg` (installs `settings-ui.txz` only if `gow.plg` somehow did not) |
 | `deploy.sh` | User clicks Install in UI | udev rules, appdata dirs, `docker-compose.yml`, containers, retrying boot hook |
 | `uninstall.sh` | Plugin remove | Stops containers, cleans `/boot/config/go`, removes udev rules |
 | `update.sh` | User clicks Update in UI | `docker compose pull && up -d` |
-| `vars.sh` | Sourced by all scripts | Shared env vars (`GOW_CFG`, `GOW_PLUGIN`, `DEFAULT_APPDATA`, …) |
+| `vars.sh` | Sourced by all scripts | Shared env vars (`GOW_CFG`, `GOW_PLUGIN`, `DEFAULT_APPDATA`, …); reads `GOW_VERSION` from the installed `gow.plg` |
+
+All scripts are shipped inside `settings-ui.txz` and installed to `/boot/config/plugins/gow/scripts/` by `gow.plg`. `scripts/` in the repo is the single source of truth; the package build copies them in.
 
 ## Config file
 
@@ -81,30 +81,26 @@ DEPLOYED=true
 
 ## Building the settings-ui package
 
-The emhttp page (`gow.page`) and its assets are shipped as a Slackware `.txz` package.
+The emhttp page (`gow.page`), its assets, and the helper scripts are shipped together as a Slackware `.txz` package. Stage the scripts into the package tree first (CI does this automatically; see `auto-release.yml`):
 
 ```sh
+mkdir -p packages/settings-ui/root/boot/config/plugins/gow/scripts
+cp scripts/*.sh packages/settings-ui/root/boot/config/plugins/gow/scripts/
+chmod +x packages/settings-ui/root/boot/config/plugins/gow/scripts/*.sh
+
 cd packages/settings-ui/root
-../../../utils/fmakepkg.sh ../../../packages/settings-ui/dist/settings-ui-<version>.txz
-cd ../dist
-sha256sum settings-ui-<version>.txz | awk '{print $1}' > settings-ui-<version>.txz.sha256
-md5sum    settings-ui-<version>.txz | awk '{print $1}' > settings-ui-<version>.txz.md5
+../../../utils/fmakepkg.sh ../../../packages/settings-ui/dist/settings-ui.txz
 ```
 
-Update the `<SHA256>` and `<MD5>` fields in `gow.plg` after each rebuild.
+The staged scripts under `root/boot/` are gitignored — never commit them.
 
-During development, serve the `dist/` directory from your local HTTP server and point `gitReleaseURL` there (see above).
+During development, serve the `dist/` directory from your local HTTP server and point `gitReleaseURL` there (see above). The `.plg` downloads `settings-ui.txz` and renames it to `settings-ui-<version>.txz` on the flash drive.
 
 ## Releasing
 
-1. Update the `version` entity in `gow.plg` to today's date (`YYYY.MM.DD`). For same-day hotfixes, append a suffix such as `a`.
-2. Update `GOW_VERSION` in `scripts/vars.sh` to match.
-3. Commit and merge the release change, then create a git tag matching the version:
-   ```sh
-   git tag 2026.04.10
-   git push origin 2026.04.10
-   ```
-4. The `release` GitHub Actions workflow triggers automatically, builds the package, and creates a GitHub release with `settings-ui.txz`, its checksums, and `gow.plg` as release assets. The moving install/update URL points at that latest release asset, so do not bump `version` without publishing the matching tag.
+Releases are automated. Merging to `main` triggers the `auto-release` workflow, which bumps the `version` entity in `gow.plg` to today's date (`YYYY.MM.DD`, with an `a`/`b`/… suffix for same-day hotfixes), tags it, builds the package, and publishes a GitHub release with `settings-ui.txz`, its checksums, and `gow.plg` as assets.
+
+`GOW_VERSION` is read at runtime from the installed `gow.plg`, so there is no second version string to keep in sync. To cut a release with a specific version instead of today's date, run the workflow manually (`workflow_dispatch`) with the `version` input.
 
 ## Adding a new package
 

--- a/gow.plg
+++ b/gow.plg
@@ -5,7 +5,6 @@
 <!ENTITY org       "games-on-whales">
 <!ENTITY version   "2026.06.05">
 <!ENTITY launch    "Settings/gow">
-<!ENTITY gitPkgURL "https://raw.githubusercontent.com/&org;/unraid-plugin/&version;">
 <!ENTITY gitReleaseURL "https://github.com/&org;/unraid-plugin/releases/download/&version;">
 <!ENTITY pluginURL "https://github.com/&org;/unraid-plugin/releases/latest/download/&name;.plg">
 <!ENTITY plugin    "/boot/config/plugins/&name;">
@@ -121,35 +120,13 @@
     </INLINE>
   </FILE>
 
-  <!-- Scripts: downloaded from the tagged release so hashes match exactly.
-       During development, point gitPkgURL at your local HTTP server (see DEVELOPING.md). -->
-
-  <FILE Name="&script_dir;/vars.sh">
-    <URL>&gitPkgURL;/scripts/vars.sh</URL>
-  </FILE>
-
-  <FILE Name="&script_dir;/preinstall.sh">
-    <URL>&gitPkgURL;/scripts/preinstall.sh</URL>
-  </FILE>
-
-  <FILE Name="&script_dir;/install.sh">
-    <URL>&gitPkgURL;/scripts/install.sh</URL>
-  </FILE>
-
-  <FILE Name="&script_dir;/deploy.sh">
-    <URL>&gitPkgURL;/scripts/deploy.sh</URL>
-  </FILE>
-
-  <FILE Name="&script_dir;/uninstall.sh">
-    <URL>&gitPkgURL;/scripts/uninstall.sh</URL>
-  </FILE>
-
-  <FILE Name="&script_dir;/update.sh">
-    <URL>&gitPkgURL;/scripts/update.sh</URL>
-  </FILE>
-
   <!-- Settings UI package (built from packages/settings-ui, see DEVELOPING.md).
-       SHA256/MD5 are filled in by the release workflow after building the txz. -->
+       This is the ONLY downloaded artifact: its filename is version-stamped, so
+       Unraid always fetches a fresh copy on update. The helper scripts
+       (deploy.sh, install.sh, …) are bundled inside it and installed to
+       &script_dir; by installpkg below. Earlier versions downloaded the scripts
+       as separate constant-path <FILE> entries, which Unraid cached and never
+       refreshed on update — users kept running a stale deploy.sh. -->
   <FILE Name="&plugin;/packages/settings-ui-&version;.txz">
     <URL>&gitReleaseURL;/settings-ui.txz</URL>
   </FILE>
@@ -157,11 +134,14 @@
   <!-- Install -->
   <FILE Run="/bin/bash">
     <INLINE>
-      chmod +x &script_dir;/*.sh
-
       echo "╔══════════════════════════╗"
       echo "║  Installing GoW Plugin   ║"
       echo "╚══════════════════════════╝"
+
+      # Lay down the settings UI page and the helper scripts (both shipped in the
+      # versioned package) before running them, so they match this exact version.
+      /sbin/installpkg &plugin;/packages/settings-ui-&version;.txz
+      chmod +x &script_dir;/*.sh
 
       if ! bash &script_dir;/preinstall.sh; then
         echo "Preconditions not met; aborting installation"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -473,6 +473,8 @@ EOF
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
+info "GoW plugin ${GOW_VERSION}"
+
 validate_network_config
 
 # Stop existing stack on reconfigure

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,6 +80,13 @@ EOF
 }
 
 install_settings_ui() {
+    # gow.plg installs the settings-ui package (which now also carries the
+    # helper scripts) before this runs, so normally it is already in place.
+    # Install defensively only if it is missing, e.g. when run standalone.
+    if [[ -f "${GOW_EMHTTP}/gow.page" ]]; then
+        info "settings-ui package already installed"
+        return
+    fi
     local pkg
     pkg=$(ls "${GOW_PACKAGE_DIR}"/settings-ui-*.txz 2>/dev/null | tail -1)
     [[ -n "$pkg" ]] || err "settings-ui package not found in ${GOW_PACKAGE_DIR}"

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -2,9 +2,15 @@
 # vars.sh — shared environment for all GoW plugin scripts
 
 export GOW_NAME="gow"
-export GOW_VERSION="2026.05.25"
 export GOW_ORG="games-on-whales"
 export GOW_PLUGIN="/boot/config/plugins/gow"
+
+# Plugin version, read from the installed .plg so it always matches what is
+# actually deployed. Avoids a hardcoded value silently drifting out of sync —
+# the same class of staleness that hid an old on-disk deploy.sh from users.
+export GOW_VERSION="$(grep -oP '<!ENTITY\s+version\s+"\K[^"]+' "${GOW_PLUGIN}.plg" 2>/dev/null || true)"
+[[ -n "$GOW_VERSION" ]] || export GOW_VERSION="unknown"
+
 export GOW_CFG="${GOW_PLUGIN}/gow.cfg"
 export GOW_SCRIPT_DIR="${GOW_PLUGIN}/scripts"
 export GOW_EMHTTP="/usr/local/emhttp/plugins/gow"


### PR DESCRIPTION
## Problem

`deploy.sh` and the other helper scripts were delivered as constant-path `<FILE>` downloads in `gow.plg`, with no checksum. Unraid caches checksum-less `<FILE>` downloads and does **not** re-fetch them on update unless the path or MD5 changes. The script path is identical on every version, so once a user had the scripts on the flash drive, plugin updates never replaced them. Only `settings-ui.txz` refreshed reliably, because its filename embeds the version.

### How it surfaced (#47)

A user updated the plugin to the release carrying the #48 NVIDIA driver-volume rebuild fix, but kept executing the **pre-fix** `deploy.sh`:

```
==> NVIDIA driver volume already exists — skipping build
```

That string only exists in the old `deploy.sh`; the fixed one prints `was built for ... — rebuilding`. Their plugin version bumped and the UI updated (the txz refreshed), but the cached `deploy.sh` did not, so the stale 580 driver volume was never rebuilt against the 610 host driver, and Wolf kept hitting `CUDA_ERROR_SYSTEM_DRIVER_MISMATCH` / EGL `BAD_ALLOC`.

This affected all six scripts on every in-place update, not just `deploy.sh`.

## Fix

Ship the scripts **inside** the version-stamped `settings-ui.txz` so they inherit its reliable refresh:

- **`gow.plg`**: removed the six loose script `<FILE>` downloads and the now-unused `gitPkgURL` entity. The install block `installpkg`s the versioned package first, which lays the scripts down at the same `/boot/config/plugins/gow/scripts/` path the UI and remove handler already use, then runs `preinstall.sh` / `install.sh`.
- **`auto-release.yml`**: stage `scripts/*.sh` into the package tree before `fmakepkg`. `.gitignore` keeps the staged copies untracked so `scripts/` stays the single source of truth.
- **`install.sh`**: install the package only if missing, so there's no double install at boot now that `gow.plg` owns it.

## Safeguard

So a stale-script situation is visible next time instead of needing a `docker volume inspect` to catch:

- **`vars.sh`**: read `GOW_VERSION` from the installed `gow.plg` at runtime, instead of a hardcoded value (it was stuck at `2026.05.25` and the release workflow never updated it).
- **`deploy.sh`**: print `==> GoW plugin <version>` at the top of every run.
- **`DEVELOPING.md`**: updated install-flow, dev-install, build, and release docs.

## Verification

- Package builds and contains all scripts at `boot/config/plugins/gow/scripts/` plus the `gow.page` UI.
- `gitPkgURL` and the loose script `<FILE>` entries are gone; `installpkg` runs before the scripts.
- `bash -n` passes on changed scripts; version parse resolves against a real `.plg` and falls back to `unknown` when absent.

> Note: branched off current `main` (`2026.06.05`), so this builds on top of the #48 driver-rebuild fix rather than reverting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)