### PR TITLE
Set WOLF_PULSE_CONTAINER_TIMEOUT_MS=30000 to fix missing audio sink (#50)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -218,6 +218,7 @@ services:
       - WOLF_CFG_FILE=/etc/wolf/cfg/config.toml
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
       - HOST_APPS_STATE_FOLDER=${APPDATA}
+      - WOLF_PULSE_CONTAINER_TIMEOUT_MS=30000
 YAML
     write_wolf_network_env
     cat <<YAML
@@ -292,6 +293,7 @@ services:
       - WOLF_CFG_FILE=/etc/wolf/cfg/config.toml
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
       - HOST_APPS_STATE_FOLDER=${APPDATA}
+      - WOLF_PULSE_CONTAINER_TIMEOUT_MS=30000
 YAML
     write_wolf_network_env
     cat <<YAML


### PR DESCRIPTION
## Problem

Issue #50: no audio sink in Steam on Unraid (AMD 6750XT).

The D-Bus / cookie warnings in the report are benign (they appear in every Wolf session). The real cause is the WolfPulseAudio startup race.

Wolf starts a sibling `WolfPulseAudio` container, sleeps a fixed `WOLF_PULSE_CONTAINER_TIMEOUT_MS` (default **2000ms**), then connects to its socket exactly once with no retry ([`wolf.cpp` `setup_audio_server`](https://github.com/games-on-whales/wolf/blob/stable/src/moonlight-server/wolf.cpp)). If the connect misses the window Wolf runs with no audio server and apps get no usable sink.

On Unraid the 2s default is fragile: appdata may be on a spun-down or busy disk, and on first launch the `pulseaudio:master` image may still be pulling. This matches games-on-whales/wolf#374, where raising the timeout to 30s resolved it (confirmed by the Wolf maintainer).

## Fix

Set `WOLF_PULSE_CONTAINER_TIMEOUT_MS=30000` in both compose templates (`write_compose_nvidia` and `write_compose_standard`) in `scripts/deploy.sh`.

Low risk: it only lengthens a one-time startup wait, and only when Wolf has to start its own PulseAudio container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)