### PR TITLE
Match Wolf's embedded PulseAudio and fix socket volume ownership

### DIFF
--- a/gow.plg
+++ b/gow.plg
@@ -23,6 +23,11 @@
 >
 
   <CHANGES>
+### 2026.06.08
+- Match Wolf's new embedded PulseAudio: Wolf now runs PulseAudio inside its own container instead of the separate WolfPulseAudio sidecar
+- Recreate the `wolf-socket` runtime volume on deploy, update, and uninstall so the embedded PulseAudio (running as root) gets a `/tmp/sockets` it owns, fixing the "XDG_RUNTIME_DIR is not owned by us" PulseAudio start failures seen after upgrading from the sidecar
+- Drop the now-unused `WOLF_PULSE_CONTAINER_TIMEOUT_MS` setting, since Wolf waits for the PulseAudio socket directly instead of sleeping for a fixed timeout
+
 ### 2026.05.30
 - Set `HOST_APPS_STATE_FOLDER` to the selected appdata path so Wolf bind-mounts spawned app containers from the chosen appdata directory instead of host `/etc/wolf`
 - Fix the Wolf Den port not changing: publish the configured host port to the container's port `8080` instead of putting Wolf Den on host networking, which ignored the setting and left it on `8080`

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -218,7 +218,6 @@ services:
       - WOLF_CFG_FILE=/etc/wolf/cfg/config.toml
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
       - HOST_APPS_STATE_FOLDER=${APPDATA}
-      - WOLF_PULSE_CONTAINER_TIMEOUT_MS=30000
 YAML
     write_wolf_network_env
     cat <<YAML
@@ -293,7 +292,6 @@ services:
       - WOLF_CFG_FILE=/etc/wolf/cfg/config.toml
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
       - HOST_APPS_STATE_FOLDER=${APPDATA}
-      - WOLF_PULSE_CONTAINER_TIMEOUT_MS=30000
 YAML
     write_wolf_network_env
     cat <<YAML
@@ -482,7 +480,14 @@ validate_network_config
 # Stop existing stack on reconfigure
 if [[ -f "$COMPOSE_FILE" ]]; then
     info "Stopping existing stack for reconfiguration"
-    docker compose -f "$COMPOSE_FILE" down 2>/dev/null || true
+    # down -v drops the non-external wolf-socket volume so it is recreated
+    # root-owned. Wolf now runs PulseAudio inside its own container (as root),
+    # and the old WolfPulseAudio sidecar left /tmp/sockets owned by the run uid
+    # (1000), which makes the embedded PulseAudio refuse to start with
+    # "XDG_RUNTIME_DIR is not owned by us". The external nvidia-driver-vol is
+    # never removed by down -v. wolf-socket only holds runtime sockets, so
+    # recreating it is safe.
+    docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
     cleanup_wolf_runtime_containers
 fi
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -18,7 +18,9 @@ fi
 COMPOSE_FILE="${APPDATA}/docker-compose.yml"
 if [[ -f "$COMPOSE_FILE" ]]; then
     info "Stopping Wolf + Wolf Den"
-    docker compose -f "$COMPOSE_FILE" down 2>/dev/null || warn "Could not stop containers cleanly"
+    # down -v also drops the non-external wolf-socket runtime volume; the
+    # external nvidia-driver-vol is left untouched.
+    docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || warn "Could not stop containers cleanly"
 fi
 
 if docker inspect WolfPulseAudio &>/dev/null; then

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -18,7 +18,15 @@ COMPOSE_FILE="${APPDATA}/docker-compose.yml"
 info "Pulling latest Wolf + Wolf Den images..."
 docker compose -f "$COMPOSE_FILE" pull
 
+# Recreate the stack with a fresh wolf-socket volume. Wolf now runs PulseAudio
+# inside its own container as root; the old WolfPulseAudio sidecar left
+# /tmp/sockets owned by the run uid (1000), which makes the embedded PulseAudio
+# refuse to start with "XDG_RUNTIME_DIR is not owned by us". down -v drops the
+# non-external wolf-socket volume (runtime sockets only) so it comes back
+# root-owned; the external nvidia-driver-vol is left untouched.
 info "Restarting stack..."
+docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+docker rm -f WolfPulseAudio >/dev/null 2>&1 || true
 docker compose -f "$COMPOSE_FILE" up -d
 
 info "Update complete."


### PR DESCRIPTION
Fixes the PulseAudio failures reported in #50 (comment by @bpivk on Unraid 7.3.1) after Wolf moved PulseAudio inside the Wolf container.

## Background

[games-on-whales/wolf#422](https://github.com/games-on-whales/wolf/pull/422) runs PulseAudio inside the Wolf container under supervisord (waiting for the PA socket before launching Wolf) instead of the external `WolfPulseAudio` sidecar. The embedded PulseAudio runs as **root**, but the persisted `wolf-socket` Docker volume kept `/tmp/sockets` owned by the old sidecar's run uid (**1000**). So on upgrade PulseAudio refused to start:

```
E: [pulseaudio] core-util.c: XDG_RUNTIME_DIR (/tmp/sockets) is not owned by us (uid 0), but by uid 1000!
```

which cascaded into `WolfApi` SSE failures in Wolf Den. @bpivk's manual workaround was `docker exec -it wolf chown root:root /tmp/sockets`.

We can't bind-mount the socket dir from `/mnt/user` (shfs/FUSE won't host unix sockets), so the named volume stays — it just needs to come back root-owned.

## Changes

- `deploy.sh`, `update.sh`, `uninstall.sh`: use `docker compose down -v` so the non-external `wolf-socket` runtime volume is recreated root-owned. The `external` `nvidia-driver-vol` is never removed by `down -v`, and `wolf-socket` only holds runtime sockets, so recreating it is safe.
- `update.sh`: also drops any leftover `WolfPulseAudio` sidecar before bringing the stack back up.
- `deploy.sh`: remove the now-unused `WOLF_PULSE_CONTAINER_TIMEOUT_MS` env. Wolf waits for the PulseAudio socket directly now, so there's no timeout to tune.
- `gow.plg`: changelog entry.

## Testing

- `bash -n` passes on all three scripts.
- Rendered the generated `docker-compose.yml` (host/standard) and confirmed it parses as valid YAML, the timeout env is gone, `XDG_RUNTIME_DIR=/tmp/sockets` is retained, and `PULSE_SERVER` is left unset so Wolf's embedded mode activates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)