### PR TITLE
Warn when nvidia_drm modeset is off (fixes #53)

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -7,6 +7,28 @@ NVIDIA hardware requires the `nvidia_drm` kernel module to load with
 `modeset=1`. Without it, Wolf either fails to start the compositor or the
 remote client shows a black frame.
 
+### Symptoms
+
+Moonlight connects but shows **"No video received from host"** (or a black
+screen), and the Wolf container log shows the EGL renderer failing to find the
+NVIDIA GPU, falling back to Mesa/ZINK, then panicking:
+
+```text
+ERROR smithay::backend::egl::ffi: [EGL] 0x3003 (BAD_ALLOC) eglQueryDevicesEXT: EGL_BAD_ALLOC error: In eglQueryDevicesEXT: Failed to allocate device list.
+libEGL warning: egl: failed to create dri2 screen
+MESA: error: ZINK: failed to choose pdev
+panicked at wayland-display-core/...: Failed to create EGLDisplay: InitFailed(Unknown(0))
+```
+
+The most common cause is `nvidia_drm modeset` being off — apply the fix below
+and reboot.
+
+> **Multiple NVIDIA GPUs?** This same EGL failure also appears when the selected
+> render node (`WOLF_RENDER_NODE`, set from the GPU you pick on the settings
+> page) points at a card that is not the one driving the display. If modeset is
+> already `Y`, reconfigure in Settings > Games on Whales and select the other
+> NVIDIA render node (`/dev/dri/renderD129`, etc.).
+
 ### Check
 
 ```bash

--- a/gow.plg
+++ b/gow.plg
@@ -23,6 +23,10 @@
 >
 
   <CHANGES>
+### 2026.06.14
+- Warn in the deploy log when an NVIDIA GPU is selected but `nvidia_drm modeset` is off, the most common cause of "No video received" / EGL `BAD_ALLOC` crashes in Wolf
+- Document the exact EGL error signature and the multi-GPU render-node case in the FAQ
+
 ### 2026.06.08
 - Match Wolf's new embedded PulseAudio: Wolf now runs PulseAudio inside its own container instead of the separate WolfPulseAudio sidecar
 - Recreate the `wolf-socket` runtime volume on deploy, update, and uninstall so the embedded PulseAudio (running as root) gets a `/tmp/sockets` it owns, fixing the "XDG_RUNTIME_DIR is not owned by us" PulseAudio start failures seen after upgrading from the sidecar

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -347,6 +347,26 @@ write_compose() {
 
 # ── NVIDIA driver volume ──────────────────────────────────────────────────────
 
+# Wolf composes the game stream through a Wayland compositor. On NVIDIA this
+# requires the nvidia_drm kernel module loaded with modeset=1; without it Wolf's
+# EGL renderer cannot enumerate the GPU, falls back to Mesa/ZINK, and panics with
+# "eglQueryDevicesEXT EGL_BAD_ALLOC" / "Failed to create EGLDisplay", so Moonlight
+# shows no video. The settings page warns about this too, but surface it here as
+# well since the deploy log is what the user watches during Install. See
+# docs/FAQ.md. Non-fatal: the volume still builds so the fix can be applied after.
+warn_if_nvidia_modeset_off() {
+    local path="/sys/module/nvidia_drm/parameters/modeset"
+    local modeset=""
+    [[ -r "$path" ]] && modeset="$(tr -d '[:space:]' < "$path" 2>/dev/null)" || true
+    [[ "$modeset" == "Y" ]] && return 0
+
+    warn "NVIDIA nvidia_drm.modeset is not enabled (found '${modeset:-unset}')."
+    warn "Wolf's Wayland compositor will fail and Moonlight will show no video"
+    warn "(EGL 'Failed to create EGLDisplay' / EGL_BAD_ALLOC in the Wolf log)."
+    warn "Fix: Tools > System Drivers > nvidia_drm, set the Modprobe.d Config File"
+    warn "to 'options nvidia_drm modeset=1', apply, and reboot. See docs/FAQ.md."
+}
+
 detect_nvidia_version() {
     NV_VERSION=$(cat /sys/module/nvidia/version 2>/dev/null) || true
     [[ -n "${NV_VERSION:-}" ]] && return
@@ -498,6 +518,7 @@ ensure_wolf_uuid
 write_compose
 
 if [[ "$GPU_VENDOR" == "NVIDIA" ]]; then
+    warn_if_nvidia_modeset_off
     build_nvidia_volume
 fi
 


### PR DESCRIPTION
## Issue

[#53](https://github.com/games-on-whales/unraid-plugin/issues/53) — *No Video Received from Host on Moonlight* (RTX A4500, driver 595.80).

The Wolf log in the report is the classic NVIDIA-Wayland-without-modeset failure:

```text
ERROR smithay::backend::egl::ffi: [EGL] 0x3003 (BAD_ALLOC) eglQueryDevicesEXT: EGL_BAD_ALLOC ...
libEGL warning: egl: failed to create dri2 screen
MESA: error: ZINK: failed to choose pdev
panicked ... Failed to create EGLDisplay: InitFailed(Unknown(0))
```

EGL can't enumerate the NVIDIA device, falls back to Mesa/ZINK, and the
compositor thread panics, so the video pipeline never starts → no video.

## Root cause

`nvidia_drm` loaded without `modeset=1`. The settings page already detects this
and warns on the setup/dashboard, but **`deploy.sh` — whose log the user watches
during Install — was silent**, and the exact error string wasn't documented
anywhere, so anyone googling `eglQueryDevicesEXT EGL_BAD_ALLOC` found nothing.

## Changes

- `scripts/deploy.sh`: non-fatal warning when an NVIDIA GPU is selected and
  `/sys/module/nvidia_drm/parameters/modeset` is not `Y`. The driver volume still
  builds so the user can apply the modeset fix and reboot without re-running.
- `docs/FAQ.md`: add the exact EGL error signature under the existing modeset
  section, plus a note covering the multi-GPU case where the wrong render node
  produces the same EGL failure even with modeset on.
- `gow.plg`: changelog.

## Notes

Scoped to surfacing/documenting the dominant cause (per the maintainer's call:
deploy-log warning + FAQ, not auto-render-node detection). I couldn't reproduce
on this dev box (no NVIDIA hardware); the warning logic was unit-tested for the
`Y` / `N` / missing-file cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)