### PR TITLE
Identity-mount appdata so Wolf config and pairing persist (#54)

### DIFF
--- a/gow.plg
+++ b/gow.plg
@@ -23,6 +23,9 @@
 >
 
   <CHANGES>
+### 2026.06.14
+- Fix Wolf config and Moonlight pairing being lost on every container restart: Wolf's `startup.sh` derives its config path from `HOST_APPS_STATE_FOLDER`, so with appdata mounted at `/etc/wolf` it wrote config/pairing to an unmounted (ephemeral) path and lost it on restart. Mount appdata at the same path inside the container as on the host (identity mount) so Wolf's config, pairing, and spawned app state all persist
+
 ### 2026.06.08
 - Match Wolf's new embedded PulseAudio: Wolf now runs PulseAudio inside its own container instead of the separate WolfPulseAudio sidecar
 - Recreate the `wolf-socket` runtime volume on deploy, update, and uninstall so the embedded PulseAudio (running as root) gets a `/tmp/sockets` it owns, fixing the "XDG_RUNTIME_DIR is not owned by us" PulseAudio start failures seen after upgrading from the sidecar

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -215,14 +215,19 @@ services:
       - WOLF_RENDER_NODE=${RENDER_NODE}
       - NVIDIA_DRIVER_VOLUME_NAME=nvidia-driver-vol
       - XDG_RUNTIME_DIR=/tmp/sockets
-      - WOLF_CFG_FILE=/etc/wolf/cfg/config.toml
+      - WOLF_CFG_FILE=${APPDATA}/cfg/config.toml
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
       - HOST_APPS_STATE_FOLDER=${APPDATA}
 YAML
     write_wolf_network_env
     cat <<YAML
     volumes:
-      - ${APPDATA}:/etc/wolf:rw
+      # Identity mount (host path == container path): Wolf's startup.sh derives
+      # WOLF_CFG_FILE and the per-app state folder from HOST_APPS_STATE_FOLDER and
+      # bind-mounts that host path into the app containers it spawns. The appdata
+      # must be reachable at the same path inside this container, otherwise Wolf
+      # writes config/pairing to an unmounted (ephemeral) dir and loses it on restart.
+      - ${APPDATA}:${APPDATA}:rw
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - /dev/:/dev/:rw
       - /run/udev:/run/udev:rw
@@ -289,14 +294,19 @@ services:
     environment:
       - WOLF_RENDER_NODE=${RENDER_NODE}
       - XDG_RUNTIME_DIR=/tmp/sockets
-      - WOLF_CFG_FILE=/etc/wolf/cfg/config.toml
+      - WOLF_CFG_FILE=${APPDATA}/cfg/config.toml
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
       - HOST_APPS_STATE_FOLDER=${APPDATA}
 YAML
     write_wolf_network_env
     cat <<YAML
     volumes:
-      - ${APPDATA}:/etc/wolf:rw
+      # Identity mount (host path == container path): Wolf's startup.sh derives
+      # WOLF_CFG_FILE and the per-app state folder from HOST_APPS_STATE_FOLDER and
+      # bind-mounts that host path into the app containers it spawns. The appdata
+      # must be reachable at the same path inside this container, otherwise Wolf
+      # writes config/pairing to an unmounted (ephemeral) dir and loses it on restart.
+      - ${APPDATA}:${APPDATA}:rw
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - /dev/:/dev/:rw
       - /run/udev:/run/udev:rw


### PR DESCRIPTION
## Problem

Reported in #54: Wolf config and Moonlight pairing are lost on every container restart.

Wolf's container `startup.sh` unconditionally re-derives its config paths from `HOST_APPS_STATE_FOLDER`:

```sh
export WOLF_CFG_FOLDER=$HOST_APPS_STATE_FOLDER/cfg
export WOLF_CFG_FILE=$WOLF_CFG_FOLDER/config.toml
export WOLF_PRIVATE_KEY_FILE=$WOLF_CFG_FOLDER/key.pem
export WOLF_PRIVATE_CERT_FILE=$WOLF_CFG_FOLDER/cert.pem
```

(So the `WOLF_CFG_FILE` we passed in the compose was already dead — `startup.sh` overrides it.)

#46 set `HOST_APPS_STATE_FOLDER` to the host appdata path but kept appdata mounted at `/etc/wolf` inside the container. Wolf then resolved its config folder to the host path (e.g. `/mnt/cache/gow/cfg`), which **isn't mounted in the container**, so it wrote `config.toml`/`key.pem`/`cert.pem` to the ephemeral container layer and lost them on every restart. Symptom: re-pair Moonlight after each restart, and the bind-mounted `cfg/` stays empty on the host.

## Fix

Mount appdata at the same path inside the container as on the host (identity mount), matching Wolf's reference compose. Now the path Wolf derives from `HOST_APPS_STATE_FOLDER` is the persistent bind mount, and is also valid when Wolf bind-mounts state into the app containers it spawns via the docker socket.

- wolf service (both nvidia + standard compose blocks): `${APPDATA}:/etc/wolf` → `${APPDATA}:${APPDATA}`, `WOLF_CFG_FILE` corrected to `${APPDATA}/cfg/config.toml`.
- wolf-den keeps its `/etc/wolf` mount (hardcoded `/etc/wolf/...` paths in its appsettings, points at the same host dir).

The persistent host config location is unchanged (`${APPDATA}/cfg/config.toml`) — same place that worked before #46, so existing configs are picked up again. No migration needed.

Credit to @shitfacevk for the diagnosis in #54.

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)