### PR TITLE
Add default run UID and GID to deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -217,6 +217,8 @@ services:
       - XDG_RUNTIME_DIR=/tmp/sockets
       - WOLF_CFG_FILE=${APPDATA}/cfg/config.toml
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
+      - WOLF_DEFAULT_RUN_UID=99
+      - WOLF_DEFAULT_RUN_GID=100
       - HOST_APPS_STATE_FOLDER=${APPDATA}
 YAML
     write_wolf_network_env
@@ -296,6 +298,8 @@ services:
       - XDG_RUNTIME_DIR=/tmp/sockets
       - WOLF_CFG_FILE=${APPDATA}/cfg/config.toml
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
+      - WOLF_DEFAULT_RUN_UID=99
+      - WOLF_DEFAULT_RUN_GID=100
       - HOST_APPS_STATE_FOLDER=${APPDATA}
 YAML
     write_wolf_network_env


### PR DESCRIPTION
Implement Unraid UID/GID defaults. See [games-on-whales/unraid-plugin](https://github.com/games-on-whales/unraid-plugin) [Issue 61](https://github.com/games-on-whales/unraid-plugin/issues/61#issue-4913124094).
