### PR TITLE
Add NVIDIA zero-copy pipeline toggle (fixes #60)

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -41,6 +41,38 @@ inside the Modprobe.d Config File editor.
 - Short summary: "for Wayland support, you need to set `nvidia_drm` modeset
   in Tools > System Drivers for your driver, then restart."
 
+## NVIDIA stream disconnects with "no video received" (zero-copy)
+
+Wolf uses a zero-copy NVIDIA pipeline that keeps frames in GPU (CUDA) memory for
+the lowest latency. On some newer NVIDIA driver branches this pipeline fails to
+negotiate, so Moonlight connects, shows the desktop for a few seconds, then
+disconnects with **"no video received from host"**. The built-in "Pong" test app
+(which does not exercise the same scaling path) may still work.
+
+### Check
+
+Look in the Wolf container log for a GStreamer negotiation failure right before
+the stream ends, for example:
+
+```text
+cudaconvertscale ... transform could not transform video/x-raw(memory:CUDAMemory) ...
+Internal data stream error.
+streaming stopped, reason not-negotiated (-4)
+[GSTREAMER] Pipeline error: Internal data stream error.
+```
+
+### Fix
+
+Turn off the zero-copy pipeline so Wolf falls back to its legacy pipeline:
+
+1. Open **Settings > Games on Whales** and click **Reconfigure**.
+2. Uncheck **NVIDIA zero-copy pipeline**.
+3. Click **Install** to re-deploy.
+
+This sets `WOLF_USE_ZERO_COPY=FALSE` on the Wolf container. It trades a little
+latency for a stream that negotiates correctly. Leave the option enabled if your
+driver works with it — zero-copy is the faster path.
+
 ## Moonlight discovery and mDNS/Avahi warnings
 
 Wolf advertises the Moonlight service with mDNS on UDP port 5353. Unraid also

--- a/gow.plg
+++ b/gow.plg
@@ -23,6 +23,9 @@
 >
 
   <CHANGES>
+### 2026.07.19
+- Add an "NVIDIA zero-copy pipeline" toggle to the setup form. Wolf's zero-copy NVIDIA pipeline fails to negotiate CUDA memory on some newer driver branches, so Moonlight connects and then disconnects with "no video received" a few seconds later (GStreamer `cudaconvertscale` "not-negotiated"). Unchecking the option sets `WOLF_USE_ZERO_COPY=FALSE` so Wolf uses its legacy pipeline; see the new FAQ entry
+
 ### 2026.06.14
 - Fix Wolf config and Moonlight pairing being lost on every container restart: Wolf's `startup.sh` derives its config path from `HOST_APPS_STATE_FOLDER`, so with appdata mounted at `/etc/wolf` it wrote config/pairing to an unmounted (ephemeral) path and lost it on restart. Mount appdata at the same path inside the container as on the host (identity mount) so Wolf's config, pairing, and spawned app state all persist
 

--- a/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
+++ b/packages/settings-ui/root/usr/local/emhttp/plugins/gow/gow.page
@@ -21,6 +21,7 @@ function load_cfg() {
         'WOLF_NETWORK_MODE' => 'host',
         'WOLF_NETWORK_NAME' => '',
         'WOLF_NETWORK_IPV4' => '',
+        'WOLF_ZERO_COPY' => 'true',
         'DEPLOYED'    => 'false',
     ];
     if (!file_exists(GOW_CFG)) return $cfg;
@@ -172,6 +173,7 @@ function has_mdns_conflict() {
 
 define('FAQ_MODESET_URL', 'https://github.com/games-on-whales/unraid-plugin/blob/main/docs/FAQ.md#nvidia-wayland-support-nvidia_drmmodeset');
 define('FAQ_MDNS_URL', 'https://github.com/games-on-whales/unraid-plugin/blob/main/docs/FAQ.md#moonlight-discovery-and-mdnsavahi-warnings');
+define('FAQ_ZERO_COPY_URL', 'https://github.com/games-on-whales/unraid-plugin/blob/main/docs/FAQ.md#nvidia-stream-disconnects-with-no-video-received-zero-copy');
 define('WOLF_DEN_PAIRING_PATH', '/Clients/Pairing');
 
 // ── Action handlers ───────────────────────────────────────────────────────────
@@ -192,6 +194,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $cfg['WOLF_NETWORK_MODE'] = $_POST['wolf_network_mode'] ?? 'host';
         $cfg['WOLF_NETWORK_NAME'] = trim($_POST['wolf_network_name'] ?? '');
         $cfg['WOLF_NETWORK_IPV4'] = trim($_POST['wolf_network_ipv4'] ?? '');
+        // Unchecked checkboxes are absent from POST — treat missing as disabled.
+        $cfg['WOLF_ZERO_COPY'] = isset($_POST['wolf_zero_copy']) ? 'true' : 'false';
 
         // Look up vendor/name/driver from the selected node
         $gpus = detect_gpus();
@@ -289,6 +293,7 @@ $pairing_url     = $wolf_den_url ? $wolf_den_url . WOLF_DEN_PAIRING_PATH : '';
 $wolf_network_mode = valid_network_mode($cfg['WOLF_NETWORK_MODE']) ? $cfg['WOLF_NETWORK_MODE'] : 'host';
 $wolf_network_name = $cfg['WOLF_NETWORK_NAME'];
 $wolf_network_ipv4 = $cfg['WOLF_NETWORK_IPV4'];
+$wolf_zero_copy    = ($cfg['WOLF_ZERO_COPY'] !== 'false');
 $moonlight_host    = ($wolf_network_mode === 'custom' && valid_ipv4($wolf_network_ipv4)) ? $wolf_network_ipv4 : $ip;
 $mdns_conflict   = $deployed && has_mdns_conflict();
 ?>
@@ -575,6 +580,21 @@ $mdns_conflict   = $deployed && has_mdns_conflict();
       apply, and reboot before installing.
       <a href="<?= FAQ_MODESET_URL ?>" target="_blank" class="gow-msg-link">Details</a>.
     </p>
+    <?php endif; ?>
+
+    <?php if ($has_nvidia): ?>
+    <div class="gow-row" style="flex-direction:column;align-items:flex-start;gap:6px;margin-top:10px">
+      <label class="gow-label" for="wolf_zero_copy">
+        <input type="checkbox" name="wolf_zero_copy" id="wolf_zero_copy" value="1"
+               <?= $wolf_zero_copy ? 'checked' : '' ?>>
+        NVIDIA zero-copy pipeline
+      </label>
+      <p class="gow-help">Leave enabled for best performance. If streams disconnect
+         a few seconds after connecting with a "no video received" error (common on
+         some newer NVIDIA driver branches), uncheck this to use Wolf's legacy
+         pipeline, then re-install.
+         <a href="<?= FAQ_ZERO_COPY_URL ?>" target="_blank" class="gow-msg-link">Details</a>.</p>
+    </div>
     <?php endif; ?>
 
     <div class="gow-actions" style="margin-top:16px">

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -23,6 +23,7 @@ WOLF_DEN_PORT="${WOLF_DEN_PORT:-8080}"
 WOLF_NETWORK_MODE="${WOLF_NETWORK_MODE:-host}"
 WOLF_NETWORK_NAME="${WOLF_NETWORK_NAME:-}"
 WOLF_NETWORK_IPV4="${WOLF_NETWORK_IPV4:-}"
+WOLF_ZERO_COPY="${WOLF_ZERO_COPY:-true}"
 [[ -n "${RENDER_NODE:-}" ]] || err "No GPU configured. Select a GPU in Settings > Games on Whales."
 [[ -n "${GPU_VENDOR:-}"  ]] || err "GPU vendor not set. Re-run setup in Settings > Games on Whales."
 if [[ ! "$WOLF_DEN_PORT" =~ ^[0-9]+$ ]] || (( WOLF_DEN_PORT < 1 || WOLF_DEN_PORT > 65535 )); then
@@ -219,6 +220,14 @@ services:
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
       - HOST_APPS_STATE_FOLDER=${APPDATA}
 YAML
+    # Wolf's zero-copy NVIDIA pipeline fails to negotiate CUDA memory on some
+    # newer driver branches (cudaconvertscale "not-negotiated", stream dies a
+    # few seconds after connecting). Setting WOLF_USE_ZERO_COPY=FALSE makes Wolf
+    # fall back to the legacy pipeline, which trades a little latency for working
+    # video. See docs/FAQ.md.
+    if [[ "${WOLF_ZERO_COPY,,}" == "false" ]]; then
+        echo "      - WOLF_USE_ZERO_COPY=FALSE"
+    fi
     write_wolf_network_env
     cat <<YAML
     volumes:


### PR DESCRIPTION
## Problem

Reported in #60. After updating the NVIDIA driver, Moonlight connects to the Wolf UI, shows a few seconds of video, then disconnects with **"no video received from host."** The built-in Pong demo still works. The Wolf container log shows the zero-copy GStreamer pipeline failing to negotiate CUDA memory:

```
cudaconvertscale3 ... transform could not transform video/x-raw(memory:CUDAMemory), format=BGRA ...
streaming stopped, reason not-negotiated (-4)
[GSTREAMER] Pipeline error: Internal data stream error.
```

Wolf's zero-copy NVIDIA pipeline keeps frames in GPU (CUDA) memory for the lowest latency, but on some newer driver branches it fails to negotiate and the stream dies. Wolf exposes `WOLF_USE_ZERO_COPY=FALSE` to fall back to its legacy pipeline.

## Change

- **Setup form:** add an **"NVIDIA zero-copy pipeline"** checkbox (default on, shown only when an NVIDIA GPU is present). Unchecking it persists `WOLF_ZERO_COPY=false` in `gow.cfg`.
- **deploy.sh:** when disabled, emit `WOLF_USE_ZERO_COPY=FALSE` on the Wolf service so Wolf uses the legacy pipeline.
- **FAQ:** new entry describing the symptom, the log signature, and the fix.
- **Changelog** entry in `gow.plg`.

Default behaviour is unchanged (zero-copy stays on); affected users flip the toggle and re-install to recover.

## Testing

- `bash -n scripts/deploy.sh` passes; verified the conditional emits the env line only for `false`/`FALSE` and never for the default.
- Cannot reproduce the driver-specific negotiation failure without the affected NVIDIA hardware.