### PR TITLE
Fix Wolf Den web UI: give the Wolf socket path a unix:// scheme (#59)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -260,7 +260,10 @@ YAML
     image: ghcr.io/games-on-whales/wolf-den:stable
     container_name: wolf-den
     environment:
-      - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
+      # The unix:// scheme is required: Wolf Den's .NET bindings only dial the
+      # UNIX socket when the path carries it, otherwise they fall back to the
+      # HTTP base address (http://localhost:80) and every API/SSE call is refused.
+      - WOLF_SOCKET_PATH=unix:///tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60
       - XDG_DATA_HOME=/app/wolf-den
     volumes:
@@ -339,7 +342,10 @@ YAML
     image: ghcr.io/games-on-whales/wolf-den:stable
     container_name: wolf-den
     environment:
-      - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
+      # The unix:// scheme is required: Wolf Den's .NET bindings only dial the
+      # UNIX socket when the path carries it, otherwise they fall back to the
+      # HTTP base address (http://localhost:80) and every API/SSE call is refused.
+      - WOLF_SOCKET_PATH=unix:///tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60
       - XDG_DATA_HOME=/app/wolf-den
     volumes:


### PR DESCRIPTION
Fixes #59.

## Problem

On Unraid, the Wolf Den web management interface loads only the template frames — all dynamic data is empty and no changes can be saved. Its logs repeat:

```
The Wolf API SSE encountered an HttpRequestException exception: Connection refused (localhost:80)
System.Net.Http.HttpRequestException: Connection refused (localhost:80)
```

## Root cause

Wolf Den's .NET client (`GamesOnWhales.Wolf.Net.Bindings`) only dials the Wolf UNIX socket when `WOLF_SOCKET_PATH` carries a `unix://` scheme:

```csharp
if (socketPath.StartsWith("unix://")) { /* connect over the UDS */ }
else { /* plain HttpClient against BaseUrl = http://localhost/ */ }
```

The plugin set a bare path (`WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock`), so the bindings took the `else` branch and dialed the default HTTP base address `http://localhost:80` over TCP — where nothing is listening — producing the repeated `Connection refused (localhost:80)`. (The `localhost:80` in the message is the request URI authority, not the real endpoint.)

## Fix

Add the `unix://` scheme to `WOLF_SOCKET_PATH` in both compose variants (NVIDIA and standard) so the bindings connect over the socket that Wolf already exposes on the shared `wolf-socket` volume. The env var is only set on the `wolf-den` service; Wolf itself keeps deriving its own socket path from `XDG_RUNTIME_DIR`, so nothing else changes.