### PR TITLE
Pass Wolf Den a plain socket path so socat can build the proxy (fixes #59)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -260,10 +260,13 @@ YAML
     image: ghcr.io/games-on-whales/wolf-den:stable
     container_name: wolf-den
     environment:
-      # The unix:// scheme is required: Wolf Den's .NET bindings only dial the
-      # UNIX socket when the path carries it, otherwise they fall back to the
-      # HTTP base address (http://localhost:80) and every API/SSE call is refused.
-      - WOLF_SOCKET_PATH=unix:///tmp/sockets/wolf.sock
+      # Plain filesystem path, NOT a unix:// URL: wolf-den's entrypoint feeds
+      # this straight to `socat ... UNIX-CONNECT:${WOLF_SOCKET_PATH}` to build a
+      # uid-1000-owned proxy at /app/wolf.sock, then re-exports the unix:// form
+      # itself for the .NET client. A unix:// prefix here makes socat treat it as
+      # a literal filename, silently (2>/dev/null) fail to create the proxy, and
+      # the socket-wait times out forever.
+      - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60
       - XDG_DATA_HOME=/app/wolf-den
     volumes:
@@ -342,10 +345,13 @@ YAML
     image: ghcr.io/games-on-whales/wolf-den:stable
     container_name: wolf-den
     environment:
-      # The unix:// scheme is required: Wolf Den's .NET bindings only dial the
-      # UNIX socket when the path carries it, otherwise they fall back to the
-      # HTTP base address (http://localhost:80) and every API/SSE call is refused.
-      - WOLF_SOCKET_PATH=unix:///tmp/sockets/wolf.sock
+      # Plain filesystem path, NOT a unix:// URL: wolf-den's entrypoint feeds
+      # this straight to `socat ... UNIX-CONNECT:${WOLF_SOCKET_PATH}` to build a
+      # uid-1000-owned proxy at /app/wolf.sock, then re-exports the unix:// form
+      # itself for the .NET client. A unix:// prefix here makes socat treat it as
+      # a literal filename, silently (2>/dev/null) fail to create the proxy, and
+      # the socket-wait times out forever.
+      - WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock
       - WOLF_SOCKET_TIMEOUT=60
       - XDG_DATA_HOME=/app/wolf-den
     volumes:


### PR DESCRIPTION
## Problem

Wolf Den crash-loops on startup, spamming:

```
Waiting for Wolf socket: unix:///tmp/sockets/wolf.sock ....
Timeout: Socket did not appear within 60s
/entrypoint.sh: line 9: kill: (-1) - No such process
```

This happens even though the `wolf` container is healthy and `/tmp/sockets/wolf.sock` exists and is readable by wolf-den (which runs as root).

## Root cause

The #59 fix set `WOLF_SOCKET_PATH=unix:///tmp/sockets/wolf.sock`. But the current `wolf-den:stable` image already handles the socket internally. Its entrypoint:

```bash
WOLF_SOCKET_PATH=${WOLF_SOCKET_PATH:-/var/run/wolf/wolf.sock}
socat UNIX-LISTEN:/app/wolf.sock,mode=600,user=1000,group=1000,... UNIX-CONNECT:${WOLF_SOCKET_PATH} 2>/dev/null &
export "WOLF_SOCKET_PATH=unix:///app/wolf.sock"
exec gosu 1000 dotnet WolfLeash.dll
```

- It expects **a plain filesystem path**, which it feeds to `socat … UNIX-CONNECT:` to build a uid-1000-owned proxy at `/app/wolf.sock` (Wolf's raw socket is root-only).
- It then **re-exports the `unix://` scheme itself** for the .NET client.

With a `unix://` prefix, socat's `UNIX-CONNECT` targets a literal (nonexistent) filename, fails **silently** (`2>/dev/null`), the proxy is never created, and the socket-wait times out forever.

The upstream maintainer confirmed the `unix://` scheme must not be set at the compose level.

## Fix

Revert both compose paths (NVIDIA + standard) to the plain `WOLF_SOCKET_PATH=/tmp/sockets/wolf.sock`, with a comment documenting why the scheme must not be added here so it isn't reintroduced.

Fixes #59