### PR TITLE
Re-own Wolf app state when the run UID changes (fixes #66)

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -73,6 +73,44 @@ This sets `WOLF_USE_ZERO_COPY=FALSE` on the Wolf container. It trades a little
 latency for a stream that negotiates correctly. Leave the option enabled if your
 driver works with it — zero-copy is the faster path.
 
+## Apps never start after updating (app state owned by the wrong user)
+
+Wolf runs the apps it launches as a fixed UID/GID and bind-mounts
+`<appdata>/profile-data/<profile>/<app>` in as the app's home directory. The
+plugin sets that to Unraid's `nobody:users` (99:100). Neither Wolf nor the app
+images re-own state that is already on disk, so app data written under a
+different UID — anything created before plugin 2026.07.19 — stays unwritable and
+the app dies during startup. Steam is the usual casualty: the container comes up,
+the desktop and taskbar appear, but Big Picture never opens.
+
+### Check
+
+In the app container's log, the startup gets as far as the runtime and then
+stops, with no window ever appearing:
+
+```text
+Setting default user uid=99(retro) gid=100(retro)
+steam.sh[226]: Running Steam on ubuntu 25.04 64-bit
+setup.sh[317]: Steam runtime environment up-to-date!
+```
+
+Confirm the mismatch from the Unraid terminal — anything not owned by `99 100`
+under `profile-data` is the problem:
+
+```bash
+find /mnt/user/appdata/gow/profile-data -maxdepth 4 ! -user 99 -printf '%u %p\n' | head
+```
+
+### Fix
+
+Open **Settings > Games on Whales** and click **Install** to re-deploy. The
+deploy script re-owns everything under `profile-data` as 99:100 and updates the
+UID/GID saved for already-paired Moonlight clients.
+
+The first re-deploy after updating walks the whole tree, so it can take a while
+if the Steam library is large. It is recorded in `<appdata>/cfg/.run-ids` and
+skipped on later deploys.
+
 ## Moonlight discovery and mDNS/Avahi warnings
 
 Wolf advertises the Moonlight service with mDNS on UDP port 5353. Unraid also

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,6 +24,14 @@ WOLF_NETWORK_MODE="${WOLF_NETWORK_MODE:-host}"
 WOLF_NETWORK_NAME="${WOLF_NETWORK_NAME:-}"
 WOLF_NETWORK_IPV4="${WOLF_NETWORK_IPV4:-}"
 WOLF_ZERO_COPY="${WOLF_ZERO_COPY:-true}"
+
+# Unraid's conventional service account is nobody:users (99:100), not the
+# 1000:1000 Wolf defaults to. Wolf hands these to every app container as
+# PUID/PGID, and the app state on disk has to be owned by the same pair —
+# see migrate_app_state_ownership.
+WOLF_RUN_UID=99
+WOLF_RUN_GID=100
+
 [[ -n "${RENDER_NODE:-}" ]] || err "No GPU configured. Select a GPU in Settings > Games on Whales."
 [[ -n "${GPU_VENDOR:-}"  ]] || err "GPU vendor not set. Re-run setup in Settings > Games on Whales."
 if [[ ! "$WOLF_DEN_PORT" =~ ^[0-9]+$ ]] || (( WOLF_DEN_PORT < 1 || WOLF_DEN_PORT > 65535 )); then
@@ -124,6 +132,47 @@ migrate_legacy_etc_wolf() {
         || warn "Could not migrate all existing Wolf data from ${legacy}"
 }
 
+# Wolf bind-mounts ${APPDATA}/profile-data/<profile>/<app> as /home/retro inside
+# each app container, which runs as WOLF_RUN_UID:WOLF_RUN_GID. Nothing re-owns
+# what is already in there — Wolf never chowns the folder, and the gow images
+# only chown the top level of $HOME — so after the run uid changed to 99:100 the
+# dotfiles, Steam library and Decky state left behind by the old uid became
+# unwritable and Steam stopped launching (issue #66).
+#
+# The stamp keeps this off the hot path: these trees hold entire Steam libraries,
+# so walking them on every Apply would be slow for no reason.
+migrate_app_state_ownership() {
+    local state_dir="${APPDATA}/profile-data"
+    local stamp="${APPDATA}/cfg/.run-ids"
+    local want="${WOLF_RUN_UID}:${WOLF_RUN_GID}"
+
+    [[ -d "$state_dir" ]] || return 0
+    [[ "$(cat "$stamp" 2>/dev/null || true)" != "$want" ]] || return 0
+
+    info "Re-owning Wolf app state under ${state_dir} as ${want} — this may take a while"
+    if chown -R "$want" "$state_dir"; then
+        printf '%s\n' "$want" > "$stamp"
+    else
+        warn "Could not re-own all of ${state_dir}; apps may fail to write their state"
+    fi
+}
+
+# WOLF_DEFAULT_RUN_UID/GID only apply to newly paired clients — clients paired
+# earlier keep the uid/gid saved in config.toml. Rewrite those so every pairing
+# runs as the user migrate_app_state_ownership just made the state folders owned
+# by, instead of a stale 1000:1000 that can no longer write them.
+normalize_client_run_ids() {
+    local cfg_file="${APPDATA}/cfg/config.toml"
+    [[ -f "$cfg_file" ]] || return 0
+    grep -q 'run_uid\|run_gid' "$cfg_file" || return 0
+
+    info "Aligning saved client run uid/gid with ${WOLF_RUN_UID}:${WOLF_RUN_GID}"
+    sed -i -E \
+        -e "s/(run_uid[[:space:]]*=[[:space:]]*)[0-9]+/\1${WOLF_RUN_UID}/g" \
+        -e "s/(run_gid[[:space:]]*=[[:space:]]*)[0-9]+/\1${WOLF_RUN_GID}/g" \
+        "$cfg_file"
+}
+
 cleanup_wolf_runtime_containers() {
     local container="WolfPulseAudio"
     if docker inspect "$container" &>/dev/null; then
@@ -218,8 +267,8 @@ services:
       - XDG_RUNTIME_DIR=/tmp/sockets
       - WOLF_CFG_FILE=${APPDATA}/cfg/config.toml
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
-      - WOLF_DEFAULT_RUN_UID=99
-      - WOLF_DEFAULT_RUN_GID=100
+      - WOLF_DEFAULT_RUN_UID=${WOLF_RUN_UID}
+      - WOLF_DEFAULT_RUN_GID=${WOLF_RUN_GID}
       - HOST_APPS_STATE_FOLDER=${APPDATA}
 YAML
     # Wolf's zero-copy NVIDIA pipeline fails to negotiate CUDA memory on some
@@ -313,8 +362,8 @@ services:
       - XDG_RUNTIME_DIR=/tmp/sockets
       - WOLF_CFG_FILE=${APPDATA}/cfg/config.toml
       - WOLF_DOCKER_SOCKET=/var/run/docker.sock
-      - WOLF_DEFAULT_RUN_UID=99
-      - WOLF_DEFAULT_RUN_GID=100
+      - WOLF_DEFAULT_RUN_UID=${WOLF_RUN_UID}
+      - WOLF_DEFAULT_RUN_GID=${WOLF_RUN_GID}
       - HOST_APPS_STATE_FOLDER=${APPDATA}
 YAML
     write_wolf_network_env
@@ -530,6 +579,8 @@ install_udev_rules
 setup_appdata_dirs
 migrate_legacy_etc_wolf
 ensure_wolf_uuid
+normalize_client_run_ids
+migrate_app_state_ownership
 write_compose
 
 if [[ "$GPU_VENDOR" == "NVIDIA" ]]; then


### PR DESCRIPTION
## Problem

#62 set `WOLF_DEFAULT_RUN_UID=99` / `WOLF_DEFAULT_RUN_GID=100` so apps run as Unraid's `nobody:users`. On existing installs this stops apps from starting — Steam in particular: the container comes up, sway and waybar appear, Big Picture never does (#66).

Wolf bind-mounts `<appdata>/profile-data/<profile>/<app>` as `/home/retro` in each app container and runs it as `PUID`/`PGID` (`sessions/common.cpp:49,66`). Nothing re-owns state that is already on disk:

- Wolf only `create_directories` on the state folder, it never chowns it (`sessions/lobbies.cpp:131`).
- The gow base image's `10-setup_user.sh` does `chown "$PUID:$PGID" "$HOME"` — **top level only**, not recursive.

So every app's dotfiles, Steam library and Decky state stayed owned by 1000 while the process became 99, and Steam dies during startup. The reporter's log stops exactly there:

```text
Setting default user uid=99(retro) gid=100(retro)
steam.sh[226]: Running Steam on ubuntu 25.04 64-bit
setup.sh[317]: Steam runtime environment up-to-date!
```

There is a second trap behind it: per Wolf's docs, `WOLF_DEFAULT_RUN_UID/GID` apply **only to newly paired clients** — clients paired earlier keep the UID saved in `config.toml`. Re-owning the folders alone would break anyone whose saved `run_uid` is still 1000.

## Fix

`scripts/deploy.sh`:

- **`migrate_app_state_ownership`** — `chown -R 99:100` over `<appdata>/profile-data`, recorded in `cfg/.run-ids` so the walk only happens when the UID/GID pair actually changes. These trees hold whole Steam libraries; walking them on every Apply would be slow for no reason.
- **`normalize_client_run_ids`** — rewrites saved `run_uid`/`run_gid` in `config.toml` so already-paired clients run as the user the state folders are now owned by, instead of a stale 1000 that can no longer write them.
- `WOLF_RUN_UID`/`WOLF_RUN_GID` become a single constant that both compose writers read, so the value handed to Wolf can't drift from the value the migration chowns to.

`docs/FAQ.md` gets an entry with the log signature, a `find` check, and the fix (click **Install**; the first re-deploy is slow, later ones are stamped and skip).

Existing users recover by re-deploying from **Settings > Games on Whales**. New installs are unaffected — `profile-data` doesn't exist yet, so the migration is a no-op and no false stamp is written.

## Verification

- `bash -n` clean.
- 12/12 pass in a functional test of both new functions against real directory trees and TOML fixtures: deep re-own, stamp written, stamped re-run is a no-op, stale stamp re-migrates, fresh install leaves no stamp, both table and inline-table TOML rewritten, unrelated keys untouched, missing config a no-op. Compose rendering confirmed to emit `99`/`100`.
- **Not verified:** that Steam actually launches afterwards — no Unraid host or GPU available. The causal chain is read off Wolf's and gow's source rather than reproduced, and the test chowns to a uid/gid pair an unprivileged user can set rather than literally 99:100. Worth a confirmation from the reporter on a real box.

## Out of scope, but noted

- `<appdata>/steam` is still created by `setup_appdata_dirs` but is unused by current Wolf, which uses `profile-data`.
- `compatibilitytools.d` is still chowned `1000:1000` for wolf-den. Nothing in this repo mounts it into an app container, but if Proton installs ever land there for the Steam app it will hit the same UID mismatch.