### PR TITLE
Install Wolf's own udev rules so gamepad input stops leaking (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ The Settings page (**Settings → Games on Whales**) covers:
 Persistent udev rules and an auto-start hook are written to
 `/boot/config/go` so the stack comes back up after a reboot.
 
+The udev rules are Wolf's own
+[`85-wolf.rules`](https://github.com/games-on-whales/wolf/blob/stable/85-wolf.rules),
+fetched from upstream each time you deploy (a bundled copy is used if the server
+is offline) and installed as `/etc/udev/rules.d/85-wolf.rules`. They keep Wolf's
+virtual controllers off the host and out of other containers; Wolf's
+`scripts/wolf-input-diag.sh` can audit them if input still leaks.
+
 ## Pairing a Moonlight client
 
 Once the stack is running, open Wolf Den's pairing page:

--- a/gow.plg
+++ b/gow.plg
@@ -23,6 +23,10 @@
 >
 
   <CHANGES>
+### 2026.08.09
+- Fix gamepad input leaking out of the streamed session (kicked back to Wolf UI, another app container launching, host desktop reacting): the plugin's hand-written udev rules matched device names Wolf no longer uses and never stripped the `uaccess` ACL. Deploy now installs Wolf's own `85-wolf.rules` (games-on-whales/wolf#455), fetched from upstream at deploy time with a bundled fallback when the host is offline
+- Install the rules as `/etc/udev/rules.d/85-wolf.rules`, the path Wolf's `scripts/wolf-input-diag.sh` checks, and remove the superseded `85-gow-virtual-inputs.rules` from both `/etc/udev/rules.d` and the flash drive
+
 ### 2026.07.19
 - Add an "NVIDIA zero-copy pipeline" toggle to the setup form. Wolf's zero-copy NVIDIA pipeline fails to negotiate CUDA memory on some newer driver branches, so Moonlight connects and then disconnects with "no video received" a few seconds later (GStreamer `cudaconvertscale` "not-negotiated"). Unchecking the option sets `WOLF_USE_ZERO_COPY=FALSE` so Wolf uses its legacy pipeline; see the new FAQ entry
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -72,39 +72,128 @@ validate_network_config() {
 
 GO_SCRIPT="/boot/config/go"
 COMPOSE_FILE="${APPDATA}/docker-compose.yml"
-UDEV_RULES_FLASH="/boot/config/gow-virtual-inputs.rules"
-UDEV_RULES_LIVE="/etc/udev/rules.d/85-gow-virtual-inputs.rules"
+# Wolf owns the udev rules for its virtual input devices. They are installed
+# under the upstream filename so Wolf's own scripts/wolf-input-diag.sh finds
+# them. The plugin used to carry its own copy, which went stale as Wolf renamed
+# devices and let controller input leak onto other seats and containers
+# (games-on-whales/wolf#455).
+UDEV_RULES_URL="https://raw.githubusercontent.com/games-on-whales/wolf/stable/85-wolf.rules"
+UDEV_RULES_FLASH="/boot/config/gow-85-wolf.rules"
+UDEV_RULES_LIVE="/etc/udev/rules.d/85-wolf.rules"
+LEGACY_UDEV_RULES_FLASH="/boot/config/gow-virtual-inputs.rules"
+LEGACY_UDEV_RULES_LIVE="/etc/udev/rules.d/85-gow-virtual-inputs.rules"
 
 # ── udev rules ────────────────────────────────────────────────────────────────
+
+# Guards against installing a captive-portal page, a GitHub error page, or a
+# truncated download as udev rules. The uinput rule is the one Wolf cannot run
+# without, so its presence is a reliable marker for "this really is the file".
+udev_rules_valid() {
+    local file="$1"
+    [[ -s "$file" ]] || return 1
+    grep -q 'KERNEL=="uinput"' "$file"
+}
+
+# Snapshot of games-on-whales/wolf@stable:85-wolf.rules, used only when the host
+# cannot reach GitHub. Refresh it when upstream changes the rules.
+write_bundled_udev_rules() {
+    cat > "$1" <<'UDEV'
+# Allows Wolf to access /dev/uinput (needed to create the virtual gamepad)
+KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput", TAG+="uaccess"
+
+# Allows Wolf to access /dev/uhid (needed for DualSense emulation)
+KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
+
+# Wolf virtual controllers: the gamepads (Xbox / DualSense / Nintendo), the
+# DualSense's "Touchpad" and "Motion Sensors" child input devices, and the
+# DualSense /dev/hidraw* node. Matching the "Wolf *virtual*" name glob covers
+# every device Wolf creates without going stale on a rename; parking them on
+# the phantom seat9 and stripping the uaccess ACL keeps them off every other
+# seat. See https://github.com/games-on-whales/wolf/issues/451
+SUBSYSTEM=="input",  ATTR{name}=="Wolf *virtual*",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+KERNEL=="hidraw*",   ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+UDEV
+}
+
+# Prefers the rules Wolf publishes so they stay in sync as Wolf's device names
+# evolve, and falls back to the rules already on the flash drive, then to the
+# bundled snapshot, when the host is offline.
+fetch_udev_rules() {
+    local tmp
+    tmp="$(mktemp)"
+    if curl -fsSL --connect-timeout 10 --max-time 30 "$UDEV_RULES_URL" -o "$tmp" \
+        && udev_rules_valid "$tmp"; then
+        info "Fetched Wolf udev rules from ${UDEV_RULES_URL}"
+        cat "$tmp" > "$UDEV_RULES_FLASH"
+        rm -f "$tmp"
+        return
+    fi
+    rm -f "$tmp"
+
+    if udev_rules_valid "$UDEV_RULES_FLASH"; then
+        warn "Could not fetch Wolf udev rules — keeping the copy at ${UDEV_RULES_FLASH}"
+        return
+    fi
+
+    warn "Could not fetch Wolf udev rules — installing the bundled copy"
+    write_bundled_udev_rules "$UDEV_RULES_FLASH"
+}
+
+# The plugin's old hand-maintained rules matched device names Wolf no longer
+# uses, so leaving them in place would only re-introduce the leak.
+remove_legacy_udev_rules() {
+    [[ -e "$LEGACY_UDEV_RULES_FLASH" || -e "$LEGACY_UDEV_RULES_LIVE" ]] || return 0
+    info "Removing superseded plugin udev rules"
+    rm -f "$LEGACY_UDEV_RULES_FLASH" "$LEGACY_UDEV_RULES_LIVE"
+}
 
 install_udev_rules() {
     info "Installing udev rules"
 
-    cat > "$UDEV_RULES_FLASH" <<'UDEV'
-KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput", TAG+="uaccess"
-KERNEL=="uhid", GROUP="input", MODE="0660", TAG+="uaccess"
-KERNEL=="hidraw*", ATTRS{name}=="Wolf PS5 (virtual) pad", GROUP="input", MODE="0660", ENV{ID_SEAT}="seat9"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf X-Box One (virtual) pad", MODE="0660", ENV{ID_SEAT}="seat9"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf PS5 (virtual) pad", MODE="0660", ENV{ID_SEAT}="seat9"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf gamepad (virtual) motion sensors", MODE="0660", ENV{ID_SEAT}="seat9"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf Nintendo (virtual) pad", MODE="0660", ENV{ID_SEAT}="seat9"
-UDEV
+    fetch_udev_rules
+    remove_legacy_udev_rules
 
     cp "$UDEV_RULES_FLASH" "$UDEV_RULES_LIVE"
     udevadm control --reload-rules 2>/dev/null || true
     udevadm trigger 2>/dev/null || true
 
+    # /etc is tmpfs on Unraid, so the rules must be restored from the flash
+    # drive on every boot. Rewrite the block rather than only appending a
+    # missing one, so existing installs pick up the new filename.
     local marker="# GoW udev rules"
-    if ! grep -qF "$marker" "$GO_SCRIPT" 2>/dev/null; then
+    local end_marker="# End GoW udev rules"
+    local marker_re="${marker//\//\\/}"
+    local end_marker_re="${end_marker//\//\\/}"
+    if grep -qF "$marker" "$GO_SCRIPT" 2>/dev/null; then
+        info "Updating udev restore in /boot/config/go"
+        if grep -qF "$end_marker" "$GO_SCRIPT" 2>/dev/null; then
+            sed -i "/${marker_re}/,/${end_marker_re}/d" "$GO_SCRIPT"
+        else
+            sed -i "/${marker_re}/,/^$/d" "$GO_SCRIPT"
+        fi
+    else
         info "Adding udev restore to /boot/config/go"
-        cat >> "$GO_SCRIPT" <<EOF
+    fi
+
+    # Removing the old block leaves the blank line that separated it behind, so
+    # trim trailing blanks before appending — otherwise every deploy grows the
+    # file by one empty line.
+    # Truncated in place so the go script keeps its permissions.
+    if [[ -f "$GO_SCRIPT" ]]; then
+        local go_body
+        go_body="$(< "$GO_SCRIPT")"
+        printf '%s\n' "$go_body" > "$GO_SCRIPT"
+    fi
+
+    cat >> "$GO_SCRIPT" <<EOF
 
 ${marker}
 cp ${UDEV_RULES_FLASH} ${UDEV_RULES_LIVE}
 udevadm control --reload-rules 2>/dev/null || true
 udevadm trigger 2>/dev/null || true
+${end_marker}
 EOF
-    fi
 }
 
 # ── appdata directories ───────────────────────────────────────────────────────

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -49,8 +49,11 @@ remove_go_block() {
 remove_go_block "# GoW udev rules"
 remove_go_block "# GoW docker-compose"
 
-# Remove udev rules
+# Remove udev rules — current filenames plus the pre-wolf#455 ones, which
+# older installs may still have on the flash drive.
 info "Removing udev rules"
+rm -f "/etc/udev/rules.d/85-wolf.rules"
+rm -f "/boot/config/gow-85-wolf.rules"
 rm -f "/etc/udev/rules.d/85-gow-virtual-inputs.rules"
 rm -f "/boot/config/gow-virtual-inputs.rules"
 udevadm control --reload-rules 2>/dev/null || true


### PR DESCRIPTION
The plugin shipped a hand-written copy of Wolf's udev rules. It matched device names Wolf no longer uses (the DualSense is created as "Wolf DualSense (virtual) pad", not "Wolf PS5 (virtual) pad") and never stripped the uaccess ACL, so a streamed controller could also drive the host and other containers.

Wolf now publishes 85-wolf.rules as the single source of truth (games-on-whales/wolf#455). Fetch it at deploy time, validate it, and fall back to the flash copy or a bundled snapshot when the host is offline. Install it as /etc/udev/rules.d/85-wolf.rules — the path Wolf's scripts/wolf-input-diag.sh audits — and drop the superseded 85-gow-virtual-inputs.rules from /etc and the flash drive.

The /boot/config/go block is now rewritten rather than only appended when absent, so existing installs stop restoring the old rules at boot.