### PR TITLE
Judge app state by write access, not ownership (#66)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,68 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  shell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Syntax-check every script
+        run: |
+          rc=0
+          while IFS= read -r f; do
+            if bash -n "$f"; then
+              echo "OK    $f"
+            else
+              echo "FAIL  $f"
+              rc=1
+            fi
+          done < <(find scripts tests utils -name '*.sh' -type f | sort)
+          exit $rc
+
+      - name: ShellCheck
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq shellcheck
+          # Errors only, and it gates. The scripts predate any linting, so there
+          # are still warning-level findings; adopting those is a separate job of
+          # work, and a step that can never fail is not worth running.
+          shellcheck -S error scripts/*.sh tests/*.sh
+
+      # The app-state suite skips its load-bearing assertions unless it can
+      # actually drop to another uid and set POSIX ACLs — exactly the two things
+      # a developer laptop usually cannot do, which is why issue #66 shipped
+      # three fixes that were never executed end to end. A runner can do both.
+      - name: Install ACL tooling
+        run: |
+          sudo apt-get install -y -qq acl
+          command -v setfacl
+          command -v setpriv
+
+      - name: app-state suite (as root, with real ACLs)
+        run: |
+          out="$(sudo bash tests/app-state.sh 2>&1)"; rc=$?
+          echo "$out"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::app-state suite failed"
+            exit 1
+          fi
+          # A skip here means the run proved nothing, and a green check that
+          # proves nothing is worse than a red one. Fail on it.
+          if echo "$out" | grep -q 'skipped'; then
+            echo "::error::the suite skipped a branch it was supposed to run here"
+            exit 1
+          fi
+
+      - name: app-state suite (unprivileged, mocked ACLs)
+        run: |
+          # The same suite must still pass where setfacl/setpriv are absent,
+          # because that is the fallback path on a host without them.
+          bash tests/app-state.sh

--- a/scripts/app-state.sh
+++ b/scripts/app-state.sh
@@ -94,12 +94,116 @@ prepare_app_state_roots() {
     done
 }
 
-# Prints the first path under $1 that is not owned by the run uid/gid, if any.
-# Depth-limited: this runs on the hot path, and a mismatch always shows up near
-# the top because the app's home directory is the mount point itself.
-first_foreign_path() {
-    find "$1" -maxdepth 3 \( ! -uid "$WOLF_RUN_UID" -o ! -gid "$WOLF_RUN_GID" \) \
-        -print -quit 2>/dev/null
+# Ownership is the wrong question. Wolf runs as root and creates the profile,
+# app and udev directories; the app images' /etc/cont-init.d scripts also run as
+# root and create $HOME/.steam and $HOME/homebrew before dropping to the run uid,
+# and Decky owns homebrew/plugins as root on purpose. All of that comes back
+# root-owned on every launch, so no host-side chown can hold it — the inheritable
+# ACL is what makes those paths writable. access(2) honours that ACL, so ask the
+# kernel rather than comparing uids (issue #66: root-owned-but-writable paths
+# were reported as breakage forever, and re-triggered a full chown -R over a
+# Steam library on every deploy).
+#
+# Resolved once: "setpriv" when we can drop to the run ids and ask, "ownership"
+# when we cannot and must fall back to over-reporting.
+app_state_probe_kind() {
+    if [[ -z "${APP_STATE_PROBE_KIND:-}" ]]; then
+        if [[ $EUID -eq 0 ]] && command -v setpriv >/dev/null 2>&1; then
+            APP_STATE_PROBE_KIND=setpriv
+        else
+            APP_STATE_PROBE_KIND=ownership
+        fi
+    fi
+    printf '%s' "$APP_STATE_PROBE_KIND"
+}
+
+# --clear-groups matters: an app container has no supplementary groups, so
+# neither may this probe, or it reports access the app will not have.
+#
+# Run uid 0 falls back deliberately: root bypasses the permission bits, so a
+# probe as root answers "writable" for every path and proves nothing. Real
+# installs never get here — valid_run_id() rejects 0 and both entry points
+# validate before calling — but a probe that silently always passes is the kind
+# of check that certifies a broken tree, so refuse it rather than trust it.
+run_ids_can_write() {
+    local path="$1" owner
+    if [[ "$(app_state_probe_kind)" == setpriv && "$WOLF_RUN_UID" -ne 0 ]]; then
+        if [[ -d "$path" ]]; then
+            setpriv --reuid="$WOLF_RUN_UID" --regid="$WOLF_RUN_GID" --clear-groups \
+                test -w "$path" -a -x "$path" 2>/dev/null
+        else
+            setpriv --reuid="$WOLF_RUN_UID" --regid="$WOLF_RUN_GID" --clear-groups \
+                test -w "$path" 2>/dev/null
+        fi
+        return
+    fi
+    owner="$(stat -c '%u:%g' "$path" 2>/dev/null)" || return 1
+    [[ "$owner" == "${WOLF_RUN_UID}:${WOLF_RUN_GID}" ]]
+}
+
+# How deep to look. These trees hold entire Steam libraries, so the walk has to
+# be bounded, and a fault shows up near the top because the app's home directory
+# is the mount point itself: state root is depth 0, profile 1, app HOME 2, and
+# the directories the app image creates as root ($HOME/.steam, $HOME/homebrew)
+# are 3, with their children at 4.
+#
+# The repair and the doctor MUST share this. When they disagreed, diagnose.sh
+# reported a path at depth 4 that migrate_app_state_ownership never looked at,
+# so "fix: run Install" never cleared the warning it told the user to fix.
+APP_STATE_PROBE_DEPTH=4
+
+# Probing forks a process per path, so bound the candidate list. Only paths not
+# already owned by the run ids are probed at all, and the first failure ends the
+# scan, so this cap is only reached on a tree where everything checked so far is
+# fine.
+APP_STATE_PROBE_LIMIT=200
+
+# Prints the first path under $1 the run ids cannot write, if any. Ownership is
+# only the cheap pre-filter that enumerates candidates — a path already owned by
+# the run ids is writable by definition, so nothing else needs a probe.
+first_unwritable_path() {
+    local path
+    while read -r path; do
+        [[ -n "$path" ]] || continue
+        run_ids_can_write "$path" && continue
+        printf '%s\n' "$path"
+        return 0
+    done < <(find "$1" -maxdepth "$APP_STATE_PROBE_DEPTH" \
+                 \( ! -uid "$WOLF_RUN_UID" -o ! -gid "$WOLF_RUN_GID" \) \
+                 -print 2>/dev/null | head -n "$APP_STATE_PROBE_LIMIT")
+    return 0
+}
+
+# One-time deep repair. prepare_app_state_roots only seeds the ACL down to the
+# app HOME (depth 2), so directories that already existed when that seeding was
+# introduced carry nothing — on a real install those are $HOME/.steam and
+# $HOME/homebrew, created as root by the app image long before the plugin knew
+# to seed anything. Their children inherit nothing either, so the run uid cannot
+# write them however often the shallow refresh runs.
+#
+# Walking the whole tree costs the same as the chown -R beside it, and both only
+# run when the state is actually broken, so a healthy install never pays it.
+# Once every existing directory carries the default ACL, everything Wolf and the
+# app images create below it inherits access for good.
+repair_app_state_acls() {
+    local state_dir="$1" access defaults
+    command -v setfacl >/dev/null 2>&1 || return 0
+    access="u:${WOLF_RUN_UID}:rwX,g:${WOLF_RUN_GID}:rwX,m::rwX"
+    defaults="d:u:${WOLF_RUN_UID}:rwx,d:g:${WOLF_RUN_GID}:rwx,d:m::rwx"
+
+    # rwX leaves plain files without a spurious execute bit while still making
+    # every directory traversable. Default entries go on directories only.
+    # acl 2.3.2 happens to skip files under `-R -d` rather than fail, but that
+    # is not what setfacl(1) documents, so select the directories explicitly
+    # instead of depending on the version Unraid ships.
+    if ! setfacl -R -m "$access" -- "$state_dir"; then
+        warn "Could not grant ${WOLF_RUN_UID}:${WOLF_RUN_GID} access under ${state_dir}"
+        return 1
+    fi
+    if ! find "$state_dir" -type d -exec setfacl -m "$defaults" -- {} +; then
+        warn "Could not make app access inheritable under ${state_dir}; new app directories may be unwritable"
+        return 1
+    fi
 }
 
 # Wolf bind-mounts <appdata>/<state root>/<profile>/<app> as /home/retro inside
@@ -112,9 +216,14 @@ first_foreign_path() {
 # libraries — but it is only trusted when the tree agrees with it. A stamp that
 # recorded intent rather than reality is how a half-migrated install kept
 # looking migrated.
+#
+# "Agrees with it" now means the run ids can actually write the tree, not that
+# they own it. Wolf and the app images recreate directories as root on every
+# launch, so an ownership test never settles: it re-triggered the full chown on
+# every deploy and still reported the tree as broken afterwards.
 migrate_app_state_ownership() {
     local want="${WOLF_RUN_UID}:${WOLF_RUN_GID}"
-    local stamp state_dir stamped foreign clean=true found=false
+    local stamp state_dir stamped unwritable clean=true found=false
     stamp="$(app_state_stamp)"
     stamped="$(cat "$stamp" 2>/dev/null || true)"
 
@@ -122,21 +231,26 @@ migrate_app_state_ownership() {
         [[ -n "$state_dir" ]] || continue
         found=true
 
-        foreign="$(first_foreign_path "$state_dir")"
-        if [[ "$stamped" == "$want" && -z "$foreign" ]]; then
+        unwritable="$(first_unwritable_path "$state_dir")"
+        if [[ "$stamped" == "$want" && -z "$unwritable" ]]; then
             continue
         fi
 
-        info "Re-owning Wolf app state under ${state_dir} as ${want} — this may take a while"
+        info "Repairing Wolf app state under ${state_dir} for ${want} — this may take a while"
+        # ACLs first: they are what survives the next launch, when Wolf and the
+        # app image recreate their directories as root again. The chown behind
+        # them is the fallback for a host without setfacl, and it is transient
+        # by nature.
+        repair_app_state_acls "$state_dir" || clean=false
         if ! chown -R "$want" "$state_dir"; then
             warn "Could not re-own all of ${state_dir}; apps may fail to write their state"
             clean=false
             continue
         fi
 
-        foreign="$(first_foreign_path "$state_dir")"
-        if [[ -n "$foreign" ]]; then
-            warn "${foreign} is still not owned by ${want}; apps may fail to write their state"
+        unwritable="$(first_unwritable_path "$state_dir")"
+        if [[ -n "$unwritable" ]]; then
+            warn "${want} still cannot write ${unwritable}; apps may fail to write their state"
             clean=false
         fi
     done < <(app_state_dirs)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -200,18 +200,40 @@ EOF
 
 # ── appdata directories ───────────────────────────────────────────────────────
 
+# Wolf Den's entrypoint drops privileges to this uid via gosu. It is fixed by
+# the image, not by the app run ids: apps never see these directories, because
+# Wolf gives an app container only its own home directory.
+WOLF_DEN_UID=1000
+WOLF_DEN_GID=1000
+
 setup_appdata_dirs() {
     info "Creating appdata directories at ${APPDATA}"
     mkdir -p \
         "${APPDATA}/cfg" \
         "${APPDATA}/wolf-den" \
         "${APPDATA}/covers" \
-        "${APPDATA}/steam" \
         "${APPDATA}/compatibilitytools.d"
-    # wolf-den drops privileges to UID 1000 via gosu, so its writable dirs
-    # must be accessible before the app starts.
-    chown -R 1000:1000 "${APPDATA}/wolf-den" "${APPDATA}/covers" "${APPDATA}/compatibilitytools.d" 2>/dev/null || true
-    chmod 775 "${APPDATA}/wolf-den" "${APPDATA}/covers" "${APPDATA}/compatibilitytools.d"
+    # No steam/ here on purpose. It existed only for a ${APPDATA}/steam:/etc/wolf/steam
+    # mount that went away with the identity mount, and nothing has read it since:
+    # Wolf keeps Steam's data in the app's own home under the app state root.
+    # Existing (empty) ones are left alone rather than deleted.
+
+    # covers/ and compatibilitytools.d/ no longer have mounts of their own —
+    # wolf-den reaches them through ${APPDATA}:/etc/wolf, which lands them at the
+    # same in-container paths the explicit mounts used to provide. They still
+    # have to be writable by the uid wolf-den runs as before it starts.
+    #
+    # A failing chown must not abort the deploy (some appdata shares sit on
+    # filesystems that refuse it) but it must not pass silently either: this used
+    # to be `2>/dev/null || true` next to an unguarded chmod, so the failure that
+    # actually breaks Wolf Den was the one that got hidden.
+    local dir
+    for dir in "${APPDATA}/wolf-den" "${APPDATA}/covers" "${APPDATA}/compatibilitytools.d"; do
+        chown -R "${WOLF_DEN_UID}:${WOLF_DEN_GID}" "$dir" \
+            || warn "Could not give ${dir} to ${WOLF_DEN_UID}:${WOLF_DEN_GID}; Wolf Den may fail to write it"
+        chmod 775 "$dir" \
+            || warn "Could not set mode 775 on ${dir}; Wolf Den may fail to write it"
+    done
 }
 
 migrate_legacy_etc_wolf() {

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -67,20 +67,64 @@ else
     bad "no config.toml at ${cfg_toml}"
 fi
 
-section "App state ownership"
+section "App state access"
 stamp="$(app_state_stamp)"
 note "stamp:    $(cat "$stamp" 2>/dev/null || echo '(none)')"
+# Root ownership inside the app state tree is normal: Wolf creates the profile,
+# app and udev directories as root, and the app images create $HOME/.steam and
+# $HOME/homebrew from root-run init scripts. What matters is whether the run ids
+# can write them, which the inherited ACL decides — so report that, not the uid.
+if [[ "$(app_state_probe_kind)" == ownership ]]; then
+    note "check:    ownership only — setpriv is unavailable or this is not running"
+    note "          as root, so root-owned paths an ACL makes writable are over-reported"
+else
+    note "check:    real write access as ${WANT} (honours inherited ACLs)"
+fi
+
+# One line of ACL context per bad path: the run uid's entry and the mask are
+# what explain a path that looks permissive but is not (a chmod clips the mask
+# and with it every named entry).
+acl_summary() {
+    command -v getfacl >/dev/null 2>&1 || return 0
+    getfacl -p --omit-header -- "$1" 2>/dev/null \
+        | grep -E "^(user:${WOLF_RUN_UID}:|mask::)" | tr '\n' ' '
+}
+
 found=false
 while read -r dir; do
     [[ -n "$dir" ]] || continue
     found=true
-    foreign="$(find "$dir" -maxdepth 4 \( ! -uid "$WOLF_RUN_UID" -o ! -gid "$WOLF_RUN_GID" \) \
-                 -printf '%u:%g %p\n' 2>/dev/null | head -5)"
-    if [[ -z "$foreign" ]]; then
-        ok "${dir} is owned by ${WANT}"
+    unwritable=""
+    inherited=0
+    while read -r path; do
+        [[ -n "$path" ]] || continue
+        if run_ids_can_write "$path"; then
+            inherited=$((inherited + 1))
+            continue
+        fi
+        unwritable+="${path}"$'\n'
+    done < <(find "$dir" -maxdepth "$APP_STATE_PROBE_DEPTH" \
+                 \( ! -uid "$WOLF_RUN_UID" -o ! -gid "$WOLF_RUN_GID" \) \
+                 -print 2>/dev/null | head -n "$APP_STATE_PROBE_LIMIT")
+
+    if [[ -z "$unwritable" ]]; then
+        ok "${WANT} can write everything under ${dir}"
+        (( inherited > 0 )) && note "${inherited} path(s) are root-owned by design; the inherited ACL keeps them writable"
     else
-        bad "${dir} has paths not owned by ${WANT}:"
-        while read -r line; do note "  ${line}"; done <<< "$foreign"
+        # Say what was actually established. The fallback only compared uids, so
+        # claiming the app cannot write these paths would be asserting more than
+        # was checked.
+        if [[ "$(app_state_probe_kind)" == ownership ]]; then
+            bad "these paths under ${dir} are not owned by ${WANT}:"
+        else
+            bad "${WANT} cannot write these paths under ${dir}:"
+        fi
+        while read -r path; do
+            [[ -n "$path" ]] || continue
+            note "  $(stat -c '%U:%G %a' "$path" 2>/dev/null) ${path}"
+            acl="$(acl_summary "$path")"
+            [[ -n "$acl" ]] && note "      acl: ${acl}"
+        done < <(printf '%s' "$unwritable" | head -5)
         note "apps cannot write their own home directory — this stops Steam at startup"
         note "fix: Settings > Games on Whales > Install (or Update Images)"
     fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+# utils.sh — package name/URL helpers and checked downloads. Sourced, not run.
+
 export KERNEL_VER="$(uname -r)"
 export PACKAGE_DIR="$GOW_PLUGIN/packages"
 

--- a/tests/app-state.sh
+++ b/tests/app-state.sh
@@ -18,10 +18,29 @@ chmod +x "$TMP/bin/setfacl"
 export PATH="$TMP/bin:$PATH"
 export SETFACL_LOG="$TMP/setfacl.log"
 APPDATA="$TMP/appdata"
-WOLF_RUN_UID="$(id -u)"
-WOLF_RUN_GID="$(id -g)"
+# Never use 0 as the run id, even when running as root: root bypasses the
+# permission bits, so every writability probe would answer yes and the suite
+# would certify nothing. Real installs cannot use 0 either — valid_run_id()
+# rejects it. As root, pick an unprivileged id we can chown to; otherwise the
+# only id we can hand out is our own.
+if [[ "$(id -u)" == 0 ]]; then
+    WOLF_RUN_UID=65532
+    WOLF_RUN_GID=65532
+else
+    WOLF_RUN_UID="$(id -u)"
+    WOLF_RUN_GID="$(id -g)"
+fi
 info() { :; }
 warn() { printf 'unexpected warning: %s\n' "$*" >&2; return 1; }
+
+# Directories the test creates stand in for ones a previous sync already
+# repaired. As root, mkdir leaves them owned by 0:0, which is drift the code is
+# supposed to react to — so hand them over explicitly when that is not what the
+# case under test is about. As an ordinary user they already have the run ids.
+own_as_run_ids() {
+    [[ "$(id -u)" == 0 ]] || return 0
+    chown -R "${WOLF_RUN_UID}:${WOLF_RUN_GID}" "$@"
+}
 
 # shellcheck source=../scripts/app-state.sh
 source "$ROOT/scripts/app-state.sh"
@@ -41,6 +60,7 @@ done
 # Repeated syncs may refresh ACLs on the root/profile/app levels, but must not
 # descend into a potentially huge Steam library.
 mkdir -p "$APPDATA/profile-data/user/WolfSteam/steamapps/common/game"
+own_as_run_ids "$APPDATA/profile-data"
 : > "$SETFACL_LOG"
 sync_app_state_ownership
 grep -F -- "$APPDATA/profile-data/user/WolfSteam" "$SETFACL_LOG" >/dev/null
@@ -48,6 +68,22 @@ if grep -F -- "/steamapps" "$SETFACL_LOG" >/dev/null; then
     echo "prepare_app_state_roots walked into the Steam library" >&2
     exit 1
 fi
+
+# The deep ACL repair is the expensive half, so it must stay off the hot path:
+# a healthy tree with a valid stamp gets the shallow refresh and nothing else.
+if grep -F -- '-R -m' "$SETFACL_LOG" >/dev/null; then
+    echo "recursive ACL repair ran on a healthy tree" >&2
+    exit 1
+fi
+
+# ...but a stamp that no longer matches means directories predating the ACL may
+# be sitting in the tree unwritable, which only the recursive repair can fix.
+printf '1:1\n' > "$APPDATA/cfg/.run-ids"
+: > "$SETFACL_LOG"
+migrate_app_state_ownership
+grep -F -- '-R -m' "$SETFACL_LOG" >/dev/null
+grep -F -- "d:u:${WOLF_RUN_UID}:rwx" "$SETFACL_LOG" >/dev/null
+[[ "$(cat "$APPDATA/cfg/.run-ids")" == "$WOLF_RUN_UID:$WOLF_RUN_GID" ]]
 
 # A shallow root-owned directory created later must invalidate the stamp and be
 # repaired without relying on a UID/GID change.
@@ -67,11 +103,58 @@ if [[ "$(id -u)" == 0 && -n "$REAL_SETFACL" ]] && command -v setpriv >/dev/null 
     APPDATA="$TMP/acl-appdata"
     WOLF_RUN_UID=65532
     WOLF_RUN_GID=65532
+    unset APP_STATE_PROBE_KIND
     mkdir -p "$APPDATA/cfg"
     prepare_app_state_roots
     mkdir -p "$APPDATA/profile-data/user/WolfSteam"
     setpriv --reuid="$WOLF_RUN_UID" --regid="$WOLF_RUN_GID" --clear-groups \
         test -w "$APPDATA/profile-data/user/WolfSteam"
+
+    # Reproduce issue #66 as reported: the app image's root-run init scripts
+    # create $HOME/homebrew and $HOME/.steam. Here they predate the ACL seeding,
+    # exactly like the trees of users who installed before it existed, so they
+    # carry no ACL of their own. Strip group/other access the way a root-created
+    # 0700 directory would, and the run uid is locked out.
+    deep="$APPDATA/profile-data/user/WolfSteam/homebrew/plugins"
+    mkdir -p "$deep" "$APPDATA/profile-data/user/WolfSteam/.steam"
+    setfacl -R -b -- "$APPDATA/profile-data/user/WolfSteam/homebrew" \
+                     "$APPDATA/profile-data/user/WolfSteam/.steam"
+    chmod -R 700 "$APPDATA/profile-data/user/WolfSteam/homebrew" \
+                 "$APPDATA/profile-data/user/WolfSteam/.steam"
+
+    # Red before green: without the repair the run uid must genuinely fail here.
+    # If this succeeds, the diagnosis behind this fix is wrong — say so loudly
+    # rather than letting a green suite certify nothing.
+    if run_ids_can_write "$deep"; then
+        echo "pre-repair tree is already writable — the #66 reproduction is invalid" >&2
+        exit 1
+    fi
+
+    sync_app_state_ownership
+    run_ids_can_write "$deep"
+    run_ids_can_write "$APPDATA/profile-data/user/WolfSteam/.steam"
+
+    # The next app launch recreates directories as root all over again — Wolf's
+    # udev/ folder at depth 3, Decky's plugin dirs deeper down. That is normal,
+    # and inheritance, not another sync, is what has to keep them writable.
+    fresh="$APPDATA/profile-data/user/WolfSteam/udev"
+    mkdir "$fresh" "$deep/decky-recreated"
+    [[ "$(stat -c '%u' "$fresh")" == 0 ]]
+    run_ids_can_write "$fresh"
+    run_ids_can_write "$deep/decky-recreated"
+
+    # ...and a root-owned path that inheritance has made writable must stop being
+    # reported as breakage, which is what the user kept seeing after every fix.
+    [[ -z "$(first_unwritable_path "$APPDATA/profile-data")" ]]
+
+    # $HOME/homebrew/plugins sits at APP_STATE_PROBE_DEPTH. diagnose.sh named it
+    # in the user's report, so the repair has to scan that far too — when the two
+    # used different depths, "fix: run Install" could not clear the warning it
+    # told the user to run Install for.
+    chown 0:0 "$deep"
+    setfacl -b -- "$deep"
+    chmod 700 "$deep"
+    [[ "$(first_unwritable_path "$APPDATA/profile-data")" == "$deep" ]]
 else
     echo "real ACL writability test skipped (setfacl, setpriv, and root required)" >&2
 fi


### PR DESCRIPTION
The latest report on #66 has the tell in it: the stamp reads 99:100 — so the migration ran and finished clean — and the tree is still full of root-owned paths. The repair is not failing, it is being undone.

Everything named in that report is created by root, on every app launch:

  profile-data/<profile>/<app>, <app>/udev/*
      Wolf, create_directories() in state/sessions.hpp and runners/docker.cpp
  $HOME/.steam, $HOME/homebrew/services
      the gow steam image's cont-init.d/system-services.sh, which runs as root
      before dropping to PUID
  $HOME/homebrew/plugins
      Decky's PluginLoader, deliberately

So a host-side chown can never hold, and #70 was right to reach for inheritable ACLs. Two gaps remained.

The ACL only reached depth 2. prepare_app_state_roots seeds -maxdepth 2 (state root, profile, app HOME), so directories that predate the seeding — .steam and homebrew, at depth 3 — carry no ACL, and neither do their children. Those are genuinely unwritable by the run uid. That is the live breakage.

And ownership was the wrong signal. first_foreign_path and diagnose.sh compared uid/gid, so root-owned-but-writable paths were reported as breakage forever and re-triggered a full chown -R over a Steam library on every deploy. The doctor told the user to run Install, and Install could not satisfy the check.

  - run_ids_can_write() asks the kernel via setpriv + access(2), so an inherited ACL counts. It refuses to probe as uid 0, where root bypasses the permission bits and every answer would be "writable".
  - first_foreign_path -> first_unwritable_path: ownership is now only the cheap pre-filter that enumerates candidates.
  - repair_app_state_acls() applies the ACL recursively so pre-existing deep trees gain inheritance, gated on the same drift condition as the chown, and running before it — ACLs are the half that survives the next launch.
  - migrate and diagnose now share APP_STATE_PROBE_DEPTH. They disagreed (3 vs 4), and homebrew/plugins sat in the gap: a path the doctor reported and the repair never looked at.
  - diagnose reports access rather than ownership, prints mode and the ACL entry for paths that really are stuck, and says so plainly when it had to fall back to comparing uids.

Also, from auditing the rest of the ownership surface:

  - deploy.sh no longer creates ${APPDATA}/steam. It existed only for a /etc/wolf/steam mount removed with the identity mount, and nothing has read it since. Existing ones are left alone.
  - covers/ and compatibilitytools.d/ keep 1000:1000: they lost their own mounts but wolf-den still reaches them through ${APPDATA}:/etc/wolf, at the same in-container paths.
  - that chown was `2>/dev/null || true` beside an unguarded chmod, so the failure that actually breaks Wolf Den was the one being hidden. Both now warn and let the deploy continue.
  - utils.sh gains the shebang shellcheck needs to lint it.

Tests: the suite's load-bearing assertions were skipping on any host without root and setfacl, which is most of them — three fixes shipped for this issue without those assertions ever executing. It now reproduces the reported tree, asserts red before green, and checks that a root-created directory is writable by inheritance alone. CI runs it as root with real ACLs and fails the build if it skips, because a green check that proves nothing is worse than a red one.