### PR TITLE
Refresh Wolf's udev rules from Update Images too (refs #57)

### DIFF
--- a/gow.plg
+++ b/gow.plg
@@ -23,6 +23,9 @@
 >
 
   <CHANGES>
+### 2026.08.19a
+- Refresh Wolf's udev rules from **Update Images**, not only from Install. The rules track the Wolf image and Update Images is how most people pick up a new one, so a newer Wolf could end up running against rules fetched for an older one — which is how the gamepad input leak came back after re-pulling images (refs #57). The rules now live in `scripts/udev-rules.sh`, shared by both entry points
+
 ### 2026.08.19
 - Fix Wolf's built-in "Test ball" aborting the moment it starts ("Wayland endpoint /tmp/sockets/ exists but is not a socket", games-on-whales/wolf#462). Apps that run without their own compositor have no Wayland socket, so Wolf's readiness check inspects `XDG_RUNTIME_DIR`, finds a directory, and kills the session. Deploy now sets `WOLF_SKIP_WAYLAND_SOCKET_WAIT=TRUE`, and **Update Images** patches an already-generated Compose file so existing installs are fixed without reconfiguring
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,6 +14,7 @@ info() { echo "==> $*"; }
 warn() { echo "WARN:  $*" >&2; }
 
 source "$(dirname "$0")/app-state.sh"
+source "$(dirname "$0")/udev-rules.sh"
 
 [[ $EUID -eq 0 ]] || err "Must run as root"
 
@@ -74,129 +75,6 @@ validate_network_config() {
 
 GO_SCRIPT="/boot/config/go"
 COMPOSE_FILE="${APPDATA}/docker-compose.yml"
-# Wolf owns the udev rules for its virtual input devices. They are installed
-# under the upstream filename so Wolf's own scripts/wolf-input-diag.sh finds
-# them. The plugin used to carry its own copy, which went stale as Wolf renamed
-# devices and let controller input leak onto other seats and containers
-# (games-on-whales/wolf#455).
-UDEV_RULES_URL="https://raw.githubusercontent.com/games-on-whales/wolf/stable/85-wolf.rules"
-UDEV_RULES_FLASH="/boot/config/gow-85-wolf.rules"
-UDEV_RULES_LIVE="/etc/udev/rules.d/85-wolf.rules"
-LEGACY_UDEV_RULES_FLASH="/boot/config/gow-virtual-inputs.rules"
-LEGACY_UDEV_RULES_LIVE="/etc/udev/rules.d/85-gow-virtual-inputs.rules"
-
-# ── udev rules ────────────────────────────────────────────────────────────────
-
-# Guards against installing a captive-portal page, a GitHub error page, or a
-# truncated download as udev rules. The uinput rule is the one Wolf cannot run
-# without, so its presence is a reliable marker for "this really is the file".
-udev_rules_valid() {
-    local file="$1"
-    [[ -s "$file" ]] || return 1
-    grep -q 'KERNEL=="uinput"' "$file"
-}
-
-# Snapshot of games-on-whales/wolf@stable:85-wolf.rules, used only when the host
-# cannot reach GitHub. Refresh it when upstream changes the rules.
-write_bundled_udev_rules() {
-    cat > "$1" <<'UDEV'
-# Allows Wolf to access /dev/uinput (needed to create the virtual gamepad)
-KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput", TAG+="uaccess"
-
-# Allows Wolf to access /dev/uhid (needed for DualSense emulation)
-KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
-
-# Wolf virtual controllers: the gamepads (Xbox / DualSense / Nintendo), the
-# DualSense's "Touchpad" and "Motion Sensors" child input devices, and the
-# DualSense /dev/hidraw* node. Matching the "Wolf *virtual*" name glob covers
-# every device Wolf creates without going stale on a rename; parking them on
-# the phantom seat9 and stripping the uaccess ACL keeps them off every other
-# seat. See https://github.com/games-on-whales/wolf/issues/451
-SUBSYSTEM=="input",  ATTR{name}=="Wolf *virtual*",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
-KERNEL=="hidraw*",   ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
-UDEV
-}
-
-# Prefers the rules Wolf publishes so they stay in sync as Wolf's device names
-# evolve, and falls back to the rules already on the flash drive, then to the
-# bundled snapshot, when the host is offline.
-fetch_udev_rules() {
-    local tmp
-    tmp="$(mktemp)"
-    if curl -fsSL --connect-timeout 10 --max-time 30 "$UDEV_RULES_URL" -o "$tmp" \
-        && udev_rules_valid "$tmp"; then
-        info "Fetched Wolf udev rules from ${UDEV_RULES_URL}"
-        cat "$tmp" > "$UDEV_RULES_FLASH"
-        rm -f "$tmp"
-        return
-    fi
-    rm -f "$tmp"
-
-    if udev_rules_valid "$UDEV_RULES_FLASH"; then
-        warn "Could not fetch Wolf udev rules — keeping the copy at ${UDEV_RULES_FLASH}"
-        return
-    fi
-
-    warn "Could not fetch Wolf udev rules — installing the bundled copy"
-    write_bundled_udev_rules "$UDEV_RULES_FLASH"
-}
-
-# The plugin's old hand-maintained rules matched device names Wolf no longer
-# uses, so leaving them in place would only re-introduce the leak.
-remove_legacy_udev_rules() {
-    [[ -e "$LEGACY_UDEV_RULES_FLASH" || -e "$LEGACY_UDEV_RULES_LIVE" ]] || return 0
-    info "Removing superseded plugin udev rules"
-    rm -f "$LEGACY_UDEV_RULES_FLASH" "$LEGACY_UDEV_RULES_LIVE"
-}
-
-install_udev_rules() {
-    info "Installing udev rules"
-
-    fetch_udev_rules
-    remove_legacy_udev_rules
-
-    cp "$UDEV_RULES_FLASH" "$UDEV_RULES_LIVE"
-    udevadm control --reload-rules 2>/dev/null || true
-    udevadm trigger 2>/dev/null || true
-
-    # /etc is tmpfs on Unraid, so the rules must be restored from the flash
-    # drive on every boot. Rewrite the block rather than only appending a
-    # missing one, so existing installs pick up the new filename.
-    local marker="# GoW udev rules"
-    local end_marker="# End GoW udev rules"
-    local marker_re="${marker//\//\\/}"
-    local end_marker_re="${end_marker//\//\\/}"
-    if grep -qF "$marker" "$GO_SCRIPT" 2>/dev/null; then
-        info "Updating udev restore in /boot/config/go"
-        if grep -qF "$end_marker" "$GO_SCRIPT" 2>/dev/null; then
-            sed -i "/${marker_re}/,/${end_marker_re}/d" "$GO_SCRIPT"
-        else
-            sed -i "/${marker_re}/,/^$/d" "$GO_SCRIPT"
-        fi
-    else
-        info "Adding udev restore to /boot/config/go"
-    fi
-
-    # Removing the old block leaves the blank line that separated it behind, so
-    # trim trailing blanks before appending — otherwise every deploy grows the
-    # file by one empty line.
-    # Truncated in place so the go script keeps its permissions.
-    if [[ -f "$GO_SCRIPT" ]]; then
-        local go_body
-        go_body="$(< "$GO_SCRIPT")"
-        printf '%s\n' "$go_body" > "$GO_SCRIPT"
-    fi
-
-    cat >> "$GO_SCRIPT" <<EOF
-
-${marker}
-cp ${UDEV_RULES_FLASH} ${UDEV_RULES_LIVE}
-udevadm control --reload-rules 2>/dev/null || true
-udevadm trigger 2>/dev/null || true
-${end_marker}
-EOF
-}
 
 # ── appdata directories ───────────────────────────────────────────────────────
 

--- a/scripts/udev-rules.sh
+++ b/scripts/udev-rules.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# udev-rules.sh — install Wolf's udev rules for its virtual input devices.
+#
+# Sourced by deploy.sh (Install / Apply) and update.sh (Update Images). Both
+# entry points need it for the same reason app-state.sh does: the rules have to
+# track the Wolf image, and "Update Images" is how most users pick up a new
+# one. Refreshing only from Install left a newer Wolf running against rules
+# fetched for an older one — which is how the gamepad leak came back for the
+# reporter of issue #57 ("after re-pulling the images today the issue seems to
+# have resurfaced").
+#
+# Callers must provide info() and warn().
+
+# Wolf owns the udev rules for its virtual input devices. They are installed
+# under the upstream filename so Wolf's own scripts/wolf-input-diag.sh finds
+# them. The plugin used to carry its own copy, which went stale as Wolf renamed
+# devices and let controller input leak onto other seats and containers
+# (games-on-whales/wolf#455).
+UDEV_RULES_URL="https://raw.githubusercontent.com/games-on-whales/wolf/stable/85-wolf.rules"
+UDEV_RULES_FLASH="/boot/config/gow-85-wolf.rules"
+UDEV_RULES_LIVE="/etc/udev/rules.d/85-wolf.rules"
+LEGACY_UDEV_RULES_FLASH="/boot/config/gow-virtual-inputs.rules"
+LEGACY_UDEV_RULES_LIVE="/etc/udev/rules.d/85-gow-virtual-inputs.rules"
+
+# deploy.sh sets this for its auto-start block too; default it so update.sh and
+# any other caller get the same path without having to know about it.
+GO_SCRIPT="${GO_SCRIPT:-/boot/config/go}"
+
+# Guards against installing a captive-portal page, a GitHub error page, or a
+# truncated download as udev rules. The uinput rule is the one Wolf cannot run
+# without, so its presence is a reliable marker for "this really is the file".
+udev_rules_valid() {
+    local file="$1"
+    [[ -s "$file" ]] || return 1
+    grep -q 'KERNEL=="uinput"' "$file"
+}
+
+# Snapshot of games-on-whales/wolf@stable:85-wolf.rules, used only when the host
+# cannot reach GitHub. Refresh it when upstream changes the rules.
+write_bundled_udev_rules() {
+    cat > "$1" <<'UDEV'
+# Allows Wolf to access /dev/uinput (needed to create the virtual gamepad)
+KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput", TAG+="uaccess"
+
+# Allows Wolf to access /dev/uhid (needed for DualSense emulation)
+KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
+
+# Wolf virtual controllers: the gamepads (Xbox / DualSense / Nintendo), the
+# DualSense's "Touchpad" and "Motion Sensors" child input devices, and the
+# DualSense /dev/hidraw* node. Matching the "Wolf *virtual*" name glob covers
+# every device Wolf creates without going stale on a rename; parking them on
+# the phantom seat9 and stripping the uaccess ACL keeps them off every other
+# seat. See https://github.com/games-on-whales/wolf/issues/451
+SUBSYSTEM=="input",  ATTR{name}=="Wolf *virtual*",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+KERNEL=="hidraw*",   ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+UDEV
+}
+
+# Prefers the rules Wolf publishes so they stay in sync as Wolf's device names
+# evolve, and falls back to the rules already on the flash drive, then to the
+# bundled snapshot, when the host is offline.
+fetch_udev_rules() {
+    local tmp
+    tmp="$(mktemp)"
+    if curl -fsSL --connect-timeout 10 --max-time 30 "$UDEV_RULES_URL" -o "$tmp" \
+        && udev_rules_valid "$tmp"; then
+        info "Fetched Wolf udev rules from ${UDEV_RULES_URL}"
+        cat "$tmp" > "$UDEV_RULES_FLASH"
+        rm -f "$tmp"
+        return
+    fi
+    rm -f "$tmp"
+
+    if udev_rules_valid "$UDEV_RULES_FLASH"; then
+        warn "Could not fetch Wolf udev rules — keeping the copy at ${UDEV_RULES_FLASH}"
+        return
+    fi
+
+    warn "Could not fetch Wolf udev rules — installing the bundled copy"
+    write_bundled_udev_rules "$UDEV_RULES_FLASH"
+}
+
+# The plugin's old hand-maintained rules matched device names Wolf no longer
+# uses, so leaving them in place would only re-introduce the leak.
+remove_legacy_udev_rules() {
+    [[ -e "$LEGACY_UDEV_RULES_FLASH" || -e "$LEGACY_UDEV_RULES_LIVE" ]] || return 0
+    info "Removing superseded plugin udev rules"
+    rm -f "$LEGACY_UDEV_RULES_FLASH" "$LEGACY_UDEV_RULES_LIVE"
+}
+
+install_udev_rules() {
+    info "Installing udev rules"
+
+    fetch_udev_rules
+    remove_legacy_udev_rules
+
+    cp "$UDEV_RULES_FLASH" "$UDEV_RULES_LIVE"
+    udevadm control --reload-rules 2>/dev/null || true
+    udevadm trigger 2>/dev/null || true
+
+    # /etc is tmpfs on Unraid, so the rules must be restored from the flash
+    # drive on every boot. Rewrite the block rather than only appending a
+    # missing one, so existing installs pick up the new filename.
+    local marker="# GoW udev rules"
+    local end_marker="# End GoW udev rules"
+    local marker_re="${marker//\//\\/}"
+    local end_marker_re="${end_marker//\//\\/}"
+    if grep -qF "$marker" "$GO_SCRIPT" 2>/dev/null; then
+        info "Updating udev restore in /boot/config/go"
+        if grep -qF "$end_marker" "$GO_SCRIPT" 2>/dev/null; then
+            sed -i "/${marker_re}/,/${end_marker_re}/d" "$GO_SCRIPT"
+        else
+            sed -i "/${marker_re}/,/^$/d" "$GO_SCRIPT"
+        fi
+    else
+        info "Adding udev restore to /boot/config/go"
+    fi
+
+    # Removing the old block leaves the blank line that separated it behind, so
+    # trim trailing blanks before appending — otherwise every deploy grows the
+    # file by one empty line.
+    # Truncated in place so the go script keeps its permissions.
+    if [[ -f "$GO_SCRIPT" ]]; then
+        local go_body
+        go_body="$(< "$GO_SCRIPT")"
+        printf '%s\n' "$go_body" > "$GO_SCRIPT"
+    fi
+
+    cat >> "$GO_SCRIPT" <<EOF
+
+${marker}
+cp ${UDEV_RULES_FLASH} ${UDEV_RULES_LIVE}
+udevadm control --reload-rules 2>/dev/null || true
+udevadm trigger 2>/dev/null || true
+${end_marker}
+EOF
+}

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -8,6 +8,7 @@ info() { echo "==> $*"; }
 warn() { echo "WARN:  $*" >&2; }
 
 source "$(dirname "$0")/app-state.sh"
+source "$(dirname "$0")/udev-rules.sh"
 
 # Re-owning app state needs root, same as deploy.sh.
 [[ $EUID -eq 0 ]] || err "Must run as root"
@@ -72,6 +73,12 @@ docker rm -f WolfPulseAudio >/dev/null 2>&1 || true
 # here too, not only in deploy.sh (issue #66). Runs with the stack down: Wolf
 # rewrites config.toml as it shuts down, which would undo the run-id rewrite.
 sync_app_state_ownership
+
+# The udev rules have to track the Wolf image, and Update Images is how most
+# users pick up a new one. Refreshing them only from Install left a newer Wolf
+# running against rules fetched for an older one, which is how the gamepad leak
+# came back for the reporter of issue #57 after re-pulling the images.
+install_udev_rules
 
 docker compose -f "$COMPOSE_FILE" up -d
 


### PR DESCRIPTION
install_udev_rules ran only from deploy.sh, so clicking "Update Images" pulled a new Wolf image while leaving the udev rules exactly as the last Install fetched them. The rules track Wolf's virtual device names, so a newer Wolf against older rules is precisely the gamepad-leak condition #57 describes: "after re-pulling the images today the issue seems to have resurfaced."

Same Install-vs-Update asymmetry that hid the app-state migration in #66 and the compose settings in the previous commit.

Move the rules into scripts/udev-rules.sh, following the app-state.sh precedent for code both entry points need, and call install_udev_rules from update.sh after the stack is down. The module body is unchanged from what deploy.sh had; it only gains a GO_SCRIPT default so callers that do not set it get the right path.